### PR TITLE
winceapi: WinCE message queues + Spore Origins DIB fix

### DIFF
--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -596,7 +596,7 @@ pub struct KernelState {
 }
 
 /// Saved register context for one cooperative guest thread.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct GuestThread {
     pub entry: u32,
     pub parameter: u32,
@@ -605,6 +605,15 @@ pub struct GuestThread {
     pub exit_va: u32,
     pub resume_pc: u32,
     pub handle: u32,
+    /// Synthetic `GetCurrentThreadId` value. `PostThreadMessageW`
+    /// targets a thread by this id, so it has to be stable and
+    /// non-zero for the whole life of the thread.
+    pub id: u32,
+    /// Messages posted to *this thread* rather than to a window.
+    /// `GetMessageW` running on the thread drains this queue; the
+    /// window queue (`KernelState::posted_messages`) belongs to the
+    /// main thread only.
+    pub messages: std::collections::VecDeque<(u32, u32, u32)>,
     pub saved_regs: [u32; 17],
     pub worker_regs: [u32; 17],
     pub worker_saved: bool,
@@ -631,6 +640,8 @@ impl GuestThread {
             exit_va,
             resume_pc,
             handle,
+            id: 0,
+            messages: std::collections::VecDeque::new(),
             saved_regs,
             worker_regs: [0; 17],
             worker_saved: false,
@@ -1428,8 +1439,8 @@ pub fn run_main_loop_with_hook(
         };
         match stop {
             StopReason::InstructionLimit => {
-                log::trace!("instruction slice exhausted; resuming");
                 pc = cpu.read_reg(ArmReg::Pc)?;
+                log::trace!("instruction slice exhausted; resuming at 0x{pc:08x}");
                 continue;
             }
             StopReason::Hook(addr) => {
@@ -1453,7 +1464,7 @@ pub fn run_main_loop_with_hook(
                     .iter()
                     .position(|thread| thread.exit_va == addr && !thread.finished)
                 {
-                    let thread = process.state.threads[thread_index];
+                    let thread = process.state.threads[thread_index].clone();
                     if thread.worker_saved {
                         for (index, value) in thread.saved_regs.iter().enumerate() {
                             cpu.write_reg(

--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -575,6 +575,8 @@ pub struct KernelState {
     /// handed to the guest by `GetMessageW` / `PeekMessageW`.
     /// `(hwnd, msg, wparam, lparam)`.
     pub posted_messages: VecDeque<(u32, u32, u32, u32)>,
+    pub msg_queues: HashMap<u32, MsgQueue>,
+    pub next_msg_queue_handle: u32,
     /// Per-menu table of `(item_id -> flags)`. We track the flags so
     /// that `CheckMenuItem`/`GetMenuState` round-trip the previously
     /// set state instead of always returning the same constant —
@@ -1212,6 +1214,8 @@ impl Process {
                 wave_out_format: GuestFormat::default(),
                 wave_out: Default::default(),
                 posted_messages: Default::default(),
+                msg_queues: HashMap::new(),
+                next_msg_queue_handle: 0xDEAD_E500,
                 menus: HashMap::new(),
                 next_menu_handle: 0xDEAD_2000,
                 sub_menus: HashMap::new(),
@@ -1694,4 +1698,12 @@ mod tests {
             .read_mem(PROCESS_EXIT_TRAMPOLINE_VA, 4)
             .expect("kernel trap page must be mapped");
     }
+}
+
+#[derive(Debug, Default)]
+pub struct MsgQueue {
+    pub max_messages: u32,
+    pub max_message_size: u32,
+    pub read_access: bool,
+    pub messages: VecDeque<Vec<u8>>,
 }

--- a/crates/pocket-library/src/lib.rs
+++ b/crates/pocket-library/src/lib.rs
@@ -530,9 +530,8 @@ impl Library {
             provider,
             executable,
             source_cab,
-            install_dir: header
-                .as_ref()
-                .and_then(|h| h.install_dir.clone())
+            install_dir: setup_install_dir(&files)
+                .or_else(|| header.as_ref().and_then(|h| h.install_dir.clone()))
                 .or_else(|| infer_install_dir(&files)),
             imported_at: now_unix_seconds(),
             settings: GameSettings {
@@ -846,6 +845,49 @@ fn materialise_legacy_assets(root: &Path, files: &[pocket_cab::CabFile], app_nam
     }
 }
 
+/// Install directory the cabinet's `_setup.xml` declares.
+///
+/// `_setup.xml` is the authoritative source: it is the script a real
+/// installer follows, so it names the directory the game's own code was
+/// compiled to read from. The `.000` install header is only a fallback
+/// for legacy cabinets that ship no script, and guessing from the
+/// executable's file name is a last resort.
+///
+/// `install_dirs` (every directory the `FileOperation` block writes
+/// into) is preferred over the declared `InstallDir` because the two
+/// frequently disagree: Gameloft's Sonic Unleashed declares
+/// `%CE1%\SONIC` but installs into `%CE1%\Gameloft\SONIC`, which is
+/// the path the game hard-codes. This mirrors how `pockethle run <cab>`
+/// resolves the same cabinet, so a title behaves identically whether it
+/// is launched from a file or from the library.
+fn setup_install_dir(files: &[pocket_cab::CabFile]) -> Option<String> {
+    let setup = files
+        .iter()
+        .find(|f| f.short_name.eq_ignore_ascii_case("_setup.xml"))?;
+    let data = fs::read(&setup.extracted_path).ok()?;
+    let script = pocket_cab::WinCeSetupScript::parse_bytes(&data);
+    // `install_dirs` lists every directory the script touches, which
+    // includes the Start-menu folders the shortcut lives in
+    // (`%CE2%\\Start Menu`, `%CE14%`). Those are never where a game
+    // reads its assets from, so prefer a real `\\Program Files\\`
+    // destination and fall back to the declared `InstallDir`.
+    let usable = |dir: &String| dir.len() > 1 && !dir.contains('%') && !is_shell_dir(dir);
+    script
+        .install_dirs
+        .iter()
+        .filter(|dir| usable(dir))
+        .find(|dir| dir.to_ascii_lowercase().starts_with("\\program files\\"))
+        .or_else(|| script.install_dirs.iter().find(|dir| usable(dir)))
+        .or_else(|| script.install_dir.as_ref().filter(|dir| usable(dir)))
+        .cloned()
+}
+
+/// `\\Windows\\…` holds the shell's own folders (Start menu, shortcuts),
+/// never a game's install directory.
+fn is_shell_dir(dir: &str) -> bool {
+    dir.to_ascii_lowercase().starts_with("\\windows\\")
+}
+
 fn infer_install_dir(files: &[pocket_cab::CabFile]) -> Option<String> {
     let has_asphalt_exe = files.iter().any(|file| {
         file.short_name.eq_ignore_ascii_case("ASPHAL~1.001")
@@ -1064,6 +1106,82 @@ mod tests {
             imported_at: 0,
             settings: GameSettings::default(),
         }
+    }
+
+    #[test]
+    fn setup_xml_install_dir_wins_over_the_binary_header() {
+        // A cabinet whose `_setup.xml` installs into a nested vendor
+        // directory. The library must follow the script, not the
+        // executable's own file name.
+        let root = tmpdir("setup_install_dir");
+        std::fs::create_dir_all(&root).unwrap();
+        let xml = root.join("_setup.xml");
+        std::fs::write(
+            &xml,
+            concat!(
+                "<wap-provisioningdoc>",
+                "<characteristic type=\"Install\">",
+                "<parm name=\"InstallDir\" value=\"%CE1%\\SONIC\" />",
+                "</characteristic>",
+                "<characteristic type=\"FileOperation\">",
+                "<characteristic type=\"%CE1%\\Gameloft\\SONIC\" translation=\"install\" />",
+                "</characteristic>",
+                "</wap-provisioningdoc>",
+            ),
+        )
+        .unwrap();
+        let files = vec![pocket_cab::CabFile {
+            short_name: "_setup.xml".to_string(),
+            extracted_path: xml,
+            size: 0,
+        }];
+        assert_eq!(
+            setup_install_dir(&files).as_deref(),
+            Some("\\Program Files\\Gameloft\\SONIC\\")
+        );
+    }
+
+    #[test]
+    fn setup_install_dir_is_absent_without_a_script() {
+        assert!(setup_install_dir(&[]).is_none());
+    }
+
+    #[test]
+    fn setup_install_dir_skips_the_start_menu() {
+        // Asphalt 2 3D's script makes `%CE2%\\Start Menu` before it
+        // makes `%InstallDir%`, so declaration order alone would pick
+        // the shell folder the shortcut lives in.
+        let root = tmpdir("setup_install_dir");
+        fs::create_dir_all(&root).unwrap();
+        let xml = root.join("_setup.xml");
+        fs::write(
+            &xml,
+            concat!(
+                "<wap-provisioningdoc>",
+                "<characteristic type=\"Install\">",
+                "<parm name=\"InstallDir\" value=\"%CE1%\\Asphalt 2 3D\" />",
+                "</characteristic>",
+                "<characteristic type=\"FileOperation\">",
+                "<characteristic type=\"%CE2%\\Start Menu\">",
+                "<characteristic type=\"MakeDir\" />",
+                "</characteristic>",
+                "<characteristic type=\"%InstallDir%\">",
+                "<characteristic type=\"MakeDir\" />",
+                "</characteristic>",
+                "</characteristic>",
+                "</wap-provisioningdoc>",
+            ),
+        )
+        .unwrap();
+        let files = vec![pocket_cab::CabFile {
+            short_name: "_setup.xml".to_string(),
+            extracted_path: xml,
+            size: 0,
+        }];
+        assert_eq!(
+            setup_install_dir(&files).as_deref(),
+            Some("\\Program Files\\Asphalt 2 3D\\")
+        );
     }
 
     #[test]

--- a/crates/pocket-library/src/lib.rs
+++ b/crates/pocket-library/src/lib.rs
@@ -1085,11 +1085,19 @@ mod tests {
     use std::path::PathBuf;
 
     fn tmpdir(name: &str) -> PathBuf {
+        // Tests run in parallel and `now_unix_seconds` has one-second
+        // granularity, so the timestamp alone is not unique: two tests
+        // starting in the same second used to share a directory and
+        // read each other's fixture files. A process-wide counter makes
+        // every path distinct.
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let mut p = std::env::temp_dir();
         p.push(format!(
-            "pockethle-library-test-{}-{}",
+            "pockethle-library-test-{}-{}-{}",
             name,
-            now_unix_seconds()
+            now_unix_seconds(),
+            unique
         ));
         let _ = fs::remove_dir_all(&p);
         p
@@ -1113,7 +1121,7 @@ mod tests {
         // A cabinet whose `_setup.xml` installs into a nested vendor
         // directory. The library must follow the script, not the
         // executable's own file name.
-        let root = tmpdir("setup_install_dir");
+        let root = tmpdir("setup_install_dir_vendor_subdir");
         std::fs::create_dir_all(&root).unwrap();
         let xml = root.join("_setup.xml");
         std::fs::write(
@@ -1151,7 +1159,7 @@ mod tests {
         // Asphalt 2 3D's script makes `%CE2%\\Start Menu` before it
         // makes `%InstallDir%`, so declaration order alone would pick
         // the shell folder the shortcut lives in.
-        let root = tmpdir("setup_install_dir");
+        let root = tmpdir("setup_install_dir_start_menu");
         fs::create_dir_all(&root).unwrap();
         let xml = root.join("_setup.xml");
         fs::write(

--- a/crates/pocket-library/src/lib.rs
+++ b/crates/pocket-library/src/lib.rs
@@ -104,6 +104,33 @@ impl GameEntry {
             .join(self.relative_dir())
             .join(&self.executable)
     }
+
+    /// Guest directory the installer would have written this game to,
+    /// normalised to exactly one trailing backslash (for example
+    /// `"\\Program Files\\EA\\Spore v1.0.4\\"`).
+    ///
+    /// Games that keep their assets in one archive open it by absolute
+    /// path -- Spore Origins asks for `<install dir>\data.vfs` -- so the
+    /// extracted directory has to be mounted there as well as under the
+    /// generic `\Program Files\` prefix. Without it the open fails and
+    /// the game calls through the handle it never managed to store.
+    pub fn guest_install_prefix(&self) -> Option<String> {
+        let raw = self.install_dir.as_deref()?.trim();
+        let trimmed = raw.trim_end_matches('\\');
+        if trimmed.is_empty() {
+            return None;
+        }
+        Some(format!("{trimmed}\\"))
+    }
+
+    /// Path `GetModuleFileNameW` should report for this game, derived
+    /// from [`Self::guest_install_prefix`] and the executable's file
+    /// name. Relative guest paths resolve against its directory.
+    pub fn guest_exe_path(&self) -> Option<String> {
+        let prefix = self.guest_install_prefix()?;
+        let name = self.executable.file_name()?.to_str()?;
+        Some(format!("{prefix}{name}"))
+    }
 }
 
 /// Runtime settings stored per game.
@@ -1024,6 +1051,51 @@ mod tests {
         ));
         let _ = fs::remove_dir_all(&p);
         p
+    }
+
+    fn entry_with_install_dir(install_dir: Option<&str>) -> GameEntry {
+        GameEntry {
+            id: "spore".to_string(),
+            display_name: "Spore v1.0.4".to_string(),
+            provider: None,
+            executable: PathBuf::from("extracted/spore.exe"),
+            source_cab: "spore.cab".to_string(),
+            install_dir: install_dir.map(str::to_string),
+            imported_at: 0,
+            settings: GameSettings::default(),
+        }
+    }
+
+    #[test]
+    fn guest_paths_follow_the_cabinet_install_dir() {
+        let entry = entry_with_install_dir(Some("\\Program Files\\EA\\Spore v1.0.4\\"));
+        assert_eq!(
+            entry.guest_install_prefix().as_deref(),
+            Some("\\Program Files\\EA\\Spore v1.0.4\\")
+        );
+        assert_eq!(
+            entry.guest_exe_path().as_deref(),
+            Some("\\Program Files\\EA\\Spore v1.0.4\\spore.exe")
+        );
+    }
+
+    #[test]
+    fn guest_prefix_normalises_a_missing_separator() {
+        let entry = entry_with_install_dir(Some("\\Program Files\\Asphalt 2 3D"));
+        assert_eq!(
+            entry.guest_exe_path().as_deref(),
+            Some("\\Program Files\\Asphalt 2 3D\\spore.exe")
+        );
+    }
+
+    #[test]
+    fn guest_paths_are_absent_without_an_install_dir() {
+        assert!(entry_with_install_dir(None)
+            .guest_install_prefix()
+            .is_none());
+        assert!(entry_with_install_dir(Some("  "))
+            .guest_exe_path()
+            .is_none());
     }
 
     #[test]

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -336,6 +336,13 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "PostQuitMessage", post_quit_message);
     d.register_handler(dll, "CreateProcessW", create_process_w);
     d.register_handler(dll, "PostMessageW", post_message_w);
+    d.register_handler(dll, "PostThreadMessageW", post_thread_message_w);
+    d.register_handler(dll, "CreateMsgQueue", create_msg_queue);
+    d.register_handler(dll, "ReadMsgQueue", read_msg_queue);
+    d.register_handler(dll, "WriteMsgQueue", write_msg_queue);
+    d.register_handler(dll, "GetMsgQueueInfo", get_msg_queue_info);
+    d.register_handler(dll, "CloseMsgQueue", close_msg_queue);
+    d.register_handler(dll, "OpenMsgQueue", open_msg_queue);
     d.register_handler(
         dll,
         "MsgWaitForMultipleObjectsEx",
@@ -4140,6 +4147,174 @@ fn post_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
+fn post_thread_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let thread_id = ctx.arg_u32(0)?;
+    let message = ctx.arg_u32(1)?;
+    let wparam = ctx.arg_u32(2)?;
+    let lparam = ctx.arg_u32(3)?;
+    // Same bound as `PostMessageW`: a guest that posts faster than it
+    // pumps must not grow the queue without limit.
+    if ctx.kernel.posted_messages.len() < 256 {
+        ctx.kernel
+            .posted_messages
+            .push_back((0, message, wparam, lparam));
+    }
+    log::debug!("PostThreadMessageW(thread=0x{thread_id:08x}, msg=0x{message:04x}, wp=0x{wparam:08x}, lp=0x{lparam:08x})");
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+const WAIT_TIMEOUT_RESULT: u32 = 0x102;
+
+fn read_msg_queue_options(
+    ctx: &mut CallCtx<'_>,
+    ptr: u32,
+) -> Result<(u32, u32, bool), KernelError> {
+    if ptr == 0 {
+        return Ok((0, 0, true));
+    }
+    let raw = ctx.cpu.read_mem(ptr, 20)?;
+    let max_messages = u32::from_le_bytes(raw[8..12].try_into().unwrap());
+    let max_message_size = u32::from_le_bytes(raw[12..16].try_into().unwrap());
+    let read_access = u32::from_le_bytes(raw[16..20].try_into().unwrap()) != 0;
+    Ok((max_messages, max_message_size, read_access))
+}
+
+fn create_msg_queue(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let name = ctx.arg_u32(0)?;
+    let options = ctx.arg_u32(1)?;
+    let (max_messages, max_message_size, read_access) = read_msg_queue_options(ctx, options)?;
+    let handle = ctx.kernel.next_msg_queue_handle;
+    ctx.kernel.next_msg_queue_handle = ctx.kernel.next_msg_queue_handle.wrapping_add(1);
+    ctx.kernel.msg_queues.insert(
+        handle,
+        pocket_kernel::MsgQueue {
+            max_messages: max_messages.max(1),
+            max_message_size: max_message_size.max(1),
+            read_access,
+            messages: std::collections::VecDeque::new(),
+        },
+    );
+    log::debug!("CreateMsgQueue(name=0x{name:08x}, options=0x{options:08x}, read_access={read_access}, max_messages={max_messages}, max_message_size={max_message_size}) -> 0x{handle:08x}");
+    Ok(DispatchOutcome::ReturnedR0(handle))
+}
+
+fn read_msg_queue(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let buffer = ctx.arg_u32(1)?;
+    let buffer_size = ctx.arg_u32(2)?;
+    let bytes_read = ctx.arg_u32(3)?;
+    let timeout = ctx.arg_u32(4)?;
+    let flags = ctx.arg_u32(5)?;
+    let Some(queue) = ctx.kernel.msg_queues.get_mut(&handle) else {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    };
+    let Some(message) = queue.messages.pop_front() else {
+        if bytes_read != 0 {
+            ctx.cpu.write_mem(bytes_read, &0u32.to_le_bytes())?;
+        }
+        if flags != 0 {
+            ctx.cpu.write_mem(flags, &0u32.to_le_bytes())?;
+        }
+        if timeout != 0 && timeout != 0xFFFF_FFFF {
+            return Ok(DispatchOutcome::ReturnedR0(WAIT_TIMEOUT_RESULT));
+        }
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    };
+    let n = message.len().min(buffer_size as usize);
+    if buffer != 0 && n != 0 {
+        ctx.cpu.write_mem(buffer, &message[..n])?;
+    }
+    if bytes_read != 0 {
+        ctx.cpu.write_mem(bytes_read, &(n as u32).to_le_bytes())?;
+    }
+    if flags != 0 {
+        ctx.cpu.write_mem(flags, &0u32.to_le_bytes())?;
+    }
+    Ok(DispatchOutcome::ReturnedR0(if n == message.len() {
+        1
+    } else {
+        0
+    }))
+}
+
+fn write_msg_queue(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let buffer = ctx.arg_u32(1)?;
+    let size = ctx.arg_u32(2)?;
+    let _timeout = ctx.arg_u32(3)?;
+    let _flags = ctx.arg_u32(4)?;
+    let Some(queue) = ctx.kernel.msg_queues.get_mut(&handle) else {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    };
+    if !queue.read_access
+        || buffer == 0
+        || size > queue.max_message_size
+        || queue.messages.len() as u32 >= queue.max_messages
+    {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let bytes = ctx.cpu.read_mem(buffer, size)?;
+    queue.messages.push_back(bytes);
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+fn get_msg_queue_info(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let info = ctx.arg_u32(1)?;
+    let Some(queue) = ctx.kernel.msg_queues.get(&handle) else {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    };
+    if info != 0 {
+        let mut raw = [0u8; 24];
+        raw[0..4].copy_from_slice(&24u32.to_le_bytes());
+        raw[4..8].copy_from_slice(&(queue.messages.len() as u32).to_le_bytes());
+        raw[8..12].copy_from_slice(&queue.max_messages.to_le_bytes());
+        raw[12..16].copy_from_slice(&queue.max_message_size.to_le_bytes());
+        raw[16..20].copy_from_slice(&(queue.messages.len() as u32).to_le_bytes());
+        ctx.cpu.write_mem(info, &raw)?;
+    }
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+fn close_msg_queue(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    Ok(DispatchOutcome::ReturnedR0(
+        if ctx.kernel.msg_queues.remove(&handle).is_some() {
+            1
+        } else {
+            0
+        },
+    ))
+}
+
+fn open_msg_queue(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let process_id = ctx.arg_u32(0)?;
+    let source_handle = ctx.arg_u32(1)?;
+    let options = ctx.arg_u32(2)?;
+    let source = match ctx.kernel.msg_queues.get(&source_handle) {
+        Some(source) => (
+            source.max_messages,
+            source.max_message_size,
+            source.messages.clone(),
+        ),
+        None => return Ok(DispatchOutcome::ReturnedR0(0)),
+    };
+    let handle = ctx.kernel.next_msg_queue_handle;
+    ctx.kernel.next_msg_queue_handle = ctx.kernel.next_msg_queue_handle.wrapping_add(1);
+    let (_, _, read_access) = read_msg_queue_options(ctx, options)?;
+    let queue = pocket_kernel::MsgQueue {
+        max_messages: source.0,
+        max_message_size: source.1,
+        read_access,
+        messages: source.2,
+    };
+    ctx.kernel.msg_queues.insert(handle, queue);
+    log::debug!(
+        "OpenMsgQueue(process=0x{process_id:08x}, source=0x{source_handle:08x}) -> 0x{handle:08x}"
+    );
+    Ok(DispatchOutcome::ReturnedR0(handle))
+}
+
 fn send_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let hwnd = ctx.arg_u32(0)?;
     let message = ctx.arg_u32(1)?;
@@ -6326,15 +6501,8 @@ fn create_dib_section(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
     let rgb555 = bi_bpp == 16
         && if bi_compression == 3 {
             let masks = ctx.cpu.read_mem(pbmi + bi_size, 12).unwrap_or_default();
-            if masks.len() == 12 {
-                let green = u32::from_le_bytes([masks[4], masks[5], masks[6], masks[7]]);
-                // 0x07E0 is the 6-bit green of RGB565; 0x03E0 is the
-                // 5-bit green of RGB555. Anything else we treat as
-                // 565, our native layout.
-                green == 0x0000_03E0
-            } else {
-                false
-            }
+            masks.len() == 12
+                && u32::from_le_bytes([masks[4], masks[5], masks[6], masks[7]]) == 0x0000_03E0
         } else {
             true
         };
@@ -8542,8 +8710,15 @@ fn decode_dib(
     let rgb555 = bi_bpp == 16
         && if bi_compression == 3 {
             let masks = ctx.cpu.read_mem(p_bmi + bi_size, 12).unwrap_or_default();
-            masks.len() == 12
-                && u32::from_le_bytes([masks[4], masks[5], masks[6], masks[7]]) == 0x0000_03E0
+            if masks.len() == 12 {
+                let green = u32::from_le_bytes([masks[4], masks[5], masks[6], masks[7]]);
+                // 0x07E0 is the 6-bit green of RGB565; 0x03E0 is the
+                // 5-bit green of RGB555. Anything else we treat as
+                // 565, our native layout.
+                green == 0x0000_03E0
+            } else {
+                false
+            }
         } else {
             true
         };
@@ -9216,6 +9391,8 @@ mod tests {
             wave_out_format: GuestFormat::default(),
             wave_out: Default::default(),
             posted_messages: Default::default(),
+            msg_queues: std::collections::HashMap::new(),
+            next_msg_queue_handle: 0xDEAD_E500,
             menus: std::collections::HashMap::new(),
             next_menu_handle: 0xDEAD_2000,
             sub_menus: std::collections::HashMap::new(),

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -304,6 +304,13 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "GetDlgItem", get_dlg_item);
     d.register_handler(dll, "EnumWindows", enum_windows);
     d.register_handler(dll, "IsWindowVisible", is_window_visible);
+    d.register_handler(dll, "IsWindowEnabled", is_window_enabled);
+    d.register_handler(
+        dll,
+        "GetWindowThreadProcessId",
+        get_window_thread_process_id,
+    );
+    d.register_handler(dll, "OutputDebugStringW", output_debug_string_w);
     d.register_handler(dll, "GetVersionExW", get_version_ex_w);
     d.register_handler(dll, "GetVersionExA", get_version_ex_w);
     d.register_handler(dll, "DestroyWindow", destroy_window);
@@ -635,6 +642,7 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "RegSetValueExW", reg_set_value_ex_w);
     d.register_handler(dll, "RegDeleteValueW", reg_delete_value_w);
     d.register_handler(dll, "RegCloseKey", reg_close_key);
+    d.register_handler(dll, "RegFlushKey", reg_flush_key);
 
     /// `ERROR_FILE_NOT_FOUND` — what a real device returns for a key or
     /// value that was never written.
@@ -812,6 +820,19 @@ pub fn register(d: &mut WinCeDispatcher) {
     fn reg_close_key(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
         let key = ctx.arg_u32(0)?;
         ctx.kernel.registry.close(key);
+        Ok(DispatchOutcome::ReturnedR0(0))
+    }
+
+    /// `RegFlushKey(hKey)`
+    ///
+    /// Writes a key's pending changes through to the device's registry
+    /// file. Our registry lives in memory and every write is already
+    /// visible, so there is nothing to flush: report `ERROR_SUCCESS`.
+    /// Bejeweled 2 flushes its save key after every game and treats a
+    /// failure as "storage is gone".
+    fn reg_flush_key(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+        let key = ctx.arg_u32(0)?;
+        log::debug!("RegFlushKey(key=0x{key:08x}) -> ERROR_SUCCESS");
         Ok(DispatchOutcome::ReturnedR0(0))
     }
 
@@ -6068,6 +6089,45 @@ fn is_window_visible(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErr
     Ok(DispatchOutcome::ReturnedR0((hwnd == FAKE_HWND) as u32))
 }
 
+/// `IsWindowEnabled(hwnd)`
+///
+/// We never disable the game's window, so any live handle is enabled.
+/// Returning `FALSE` here makes dialog-driven titles (Bejeweled's "New
+/// User" name entry) drop the input they just received.
+fn is_window_enabled(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let hwnd = ctx.arg_u32(0)?;
+    Ok(DispatchOutcome::ReturnedR0((hwnd == FAKE_HWND) as u32))
+}
+
+/// `GetWindowThreadProcessId(hwnd, lpdwProcessId)`
+///
+/// One process, one UI thread: report the main thread's id and, when
+/// asked, the process id `GetCurrentProcessId` hands out.
+fn get_window_thread_process_id(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let _hwnd = ctx.arg_u32(0)?;
+    let process_id_out = ctx.arg_u32(1)?;
+    if process_id_out != 0 {
+        ctx.cpu
+            .write_mem(process_id_out, &MAIN_THREAD_ID.to_le_bytes())?;
+    }
+    Ok(DispatchOutcome::ReturnedR0(MAIN_THREAD_ID))
+}
+
+/// `OutputDebugStringW(text)`
+///
+/// Forward the guest's own debug tracing into our log; it is often the
+/// only clue a game gives about what it thinks went wrong.
+fn output_debug_string_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let text_ptr = ctx.arg_u32(0)?;
+    if text_ptr != 0 {
+        if let Ok(text) = read_wstr(ctx, text_ptr, 512) {
+            let text = String::from_utf16_lossy(&text);
+            log::debug!("OutputDebugStringW: {}", text.trim_end());
+        }
+    }
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
 fn destroy_window(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     Ok(DispatchOutcome::ReturnedR0(1))
 }
@@ -6422,6 +6482,26 @@ fn wait_for_single_object(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kern
 
     let handle = ctx.arg_u32(0)?;
     let timeout = ctx.arg_u32(1)?;
+
+    // A point-to-point message queue is a waitable object on the
+    // device: the reader blocks on the handle and only calls
+    // `ReadMsgQueue` once the wait is satisfied. Whoever fills that
+    // queue is another guest thread, so an empty queue has to be a
+    // scheduling point -- answering `WAIT_OBJECT_0` here spins the
+    // reader forever and starves the writer, which is how Bejeweled
+    // hangs on its loading screen.
+    if let Some(queue) = ctx.kernel.msg_queues.get(&handle) {
+        if !queue.messages.is_empty() {
+            return Ok(DispatchOutcome::ReturnedR0(WAIT_OBJECT_0));
+        }
+        if let Some(outcome) = park_worker_and_retry(ctx)? {
+            return Ok(outcome);
+        }
+        if let Some(outcome) = resume_worker(ctx, WAIT_TIMEOUT)? {
+            return Ok(outcome);
+        }
+        return Ok(DispatchOutcome::ReturnedR0(WAIT_TIMEOUT));
+    }
 
     if let Some(ev) = ctx.kernel.events.get_mut(&handle) {
         if ev.signalled {

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -345,6 +345,12 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "OpenMsgQueue", open_msg_queue);
     d.register_handler(
         dll,
+        "RequestPowerNotifications",
+        request_power_notifications,
+    );
+    d.register_handler(dll, "StopPowerNotifications", stop_power_notifications);
+    d.register_handler(
+        dll,
         "MsgWaitForMultipleObjectsEx",
         msg_wait_for_multiple_objects,
     );
@@ -1377,6 +1383,39 @@ fn write_guest_regs(cpu: &mut dyn pocket_cpu::Cpu, values: &[u32; 17]) -> Result
     Ok(())
 }
 
+/// `GetCurrentThreadId` for the main thread. Workers get `2`, `3`, ...
+const MAIN_THREAD_ID: u32 = 1;
+
+/// Id of whichever guest thread currently owns the CPU.
+fn current_thread_id(ctx: &CallCtx<'_>) -> u32 {
+    match ctx.kernel.current_thread.checked_sub(1) {
+        None => MAIN_THREAD_ID,
+        Some(index) => ctx
+            .kernel
+            .threads
+            .get(index)
+            .map(|thread| thread.id)
+            .filter(|id| *id != 0)
+            .unwrap_or(MAIN_THREAD_ID + 1 + index as u32),
+    }
+}
+
+/// Park the running worker so that its blocking call is *retried* when
+/// it next gets the CPU, instead of returning a value it never saw a
+/// message for.
+///
+/// `GetMessageW` has no "queue was empty" return: `FALSE` means
+/// `WM_QUIT` and ends the pump. A worker whose own queue is empty
+/// therefore cannot be resumed with `r0 = 0` — Spore Origins' loader
+/// thread exits on that and the game never draws again. Parking with
+/// the API thunk as the resume address makes the call block the way it
+/// does on the device: it re-dispatches, and either finds a message or
+/// yields again.
+fn park_worker_and_retry(ctx: &mut CallCtx<'_>) -> Result<Option<DispatchOutcome>, KernelError> {
+    let thunk_va = ctx.thunk.thunk_va;
+    park_worker_at(ctx, 0, Some(thunk_va))
+}
+
 /// Park the worker thread that is currently running and give the CPU
 /// back to the main thread.
 ///
@@ -1388,11 +1427,27 @@ fn park_worker(
     ctx: &mut CallCtx<'_>,
     return_r0: u32,
 ) -> Result<Option<DispatchOutcome>, KernelError> {
+    park_worker_at(ctx, return_r0, None)
+}
+
+/// Shared body of [`park_worker`] / [`park_worker_and_retry`].
+///
+/// `resume_at` is where the worker continues when it is scheduled
+/// again: `None` means "after the call" (the normal case), `Some(va)`
+/// re-enters the API thunk so the blocking call runs again.
+fn park_worker_at(
+    ctx: &mut CallCtx<'_>,
+    return_r0: u32,
+    resume_at: Option<u32>,
+) -> Result<Option<DispatchOutcome>, KernelError> {
     let Some(thread_index) = ctx.kernel.current_thread.checked_sub(1) else {
         return Ok(None);
     };
     let mut regs = read_guest_regs(ctx.cpu)?;
-    regs[15] = ctx.cpu.read_reg(ArmReg::Lr)?;
+    regs[15] = match resume_at {
+        Some(va) => va,
+        None => ctx.cpu.read_reg(ArmReg::Lr)?,
+    };
     regs[0] = return_r0;
     let main_regs = ctx
         .kernel
@@ -4152,14 +4207,33 @@ fn post_thread_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kerne
     let message = ctx.arg_u32(1)?;
     let wparam = ctx.arg_u32(2)?;
     let lparam = ctx.arg_u32(3)?;
-    // Same bound as `PostMessageW`: a guest that posts faster than it
-    // pumps must not grow the queue without limit.
-    if ctx.kernel.posted_messages.len() < 256 {
-        ctx.kernel
-            .posted_messages
-            .push_back((0, message, wparam, lparam));
+    // A worker's queue is its own. Only messages aimed at the main
+    // thread (or at an id we never handed out — a game that posts to
+    // thread 0) fall back to the window queue, which is what every
+    // title relied on before per-thread queues existed.
+    let worker = ctx
+        .kernel
+        .threads
+        .iter_mut()
+        .find(|thread| thread.id == thread_id && thread_id != 0 && !thread.finished);
+    match worker {
+        Some(thread) => {
+            // Same bound as `PostMessageW`: a guest that posts faster
+            // than it pumps must not grow the queue without limit.
+            if thread.messages.len() < 256 {
+                thread.messages.push_back((message, wparam, lparam));
+            }
+            log::debug!("PostThreadMessageW(thread={thread_id}, msg=0x{message:04x}, wp=0x{wparam:08x}, lp=0x{lparam:08x}) -> worker queue");
+        }
+        None => {
+            if ctx.kernel.posted_messages.len() < 256 {
+                ctx.kernel
+                    .posted_messages
+                    .push_back((0, message, wparam, lparam));
+            }
+            log::debug!("PostThreadMessageW(thread=0x{thread_id:08x}, msg=0x{message:04x}, wp=0x{wparam:08x}, lp=0x{lparam:08x}) -> window queue");
+        }
     }
-    log::debug!("PostThreadMessageW(thread=0x{thread_id:08x}, msg=0x{message:04x}, wp=0x{wparam:08x}, lp=0x{lparam:08x})");
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
@@ -4255,6 +4329,27 @@ fn write_msg_queue(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError
     }
     let bytes = ctx.cpu.read_mem(buffer, size)?;
     queue.messages.push_back(bytes);
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+/// `HANDLE RequestPowerNotifications(HANDLE hMsgQ, DWORD dwFlags)`
+///
+/// The power manager would start pushing `POWER_BROADCAST` records into
+/// the caller's message queue. Nothing in the emulator suspends or
+/// changes power state, so the queue simply stays empty — but the call
+/// has to succeed: Spore Origins treats a NULL return as a fatal
+/// initialisation error.
+fn request_power_notifications(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let queue = ctx.arg_u32(0)?;
+    let flags = ctx.arg_u32(1)?;
+    log::debug!(
+        "RequestPowerNotifications(queue=0x{queue:08x}, flags=0x{flags:08x}) -> 0xdeade4f0"
+    );
+    Ok(DispatchOutcome::ReturnedR0(0xDEAD_E4F0))
+}
+
+/// `BOOL StopPowerNotifications(HANDLE h)`
+fn stop_power_notifications(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
@@ -4736,6 +4831,24 @@ fn get_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
         write_synthetic_msg(ctx.cpu, lp_msg, WM_QUIT, 0, 0)?;
         return Ok(DispatchOutcome::ReturnedR0(0));
     }
+    // A worker running its own pump must never be handed the window
+    // queue's synthetic paint/timer traffic: it would keep dispatching
+    // forever and the main thread — the one that actually renders —
+    // would never get the CPU back.
+    if let Some(thread_index) = ctx.kernel.current_thread.checked_sub(1) {
+        let queued = ctx
+            .kernel
+            .threads
+            .get_mut(thread_index)
+            .and_then(|thread| thread.messages.pop_front());
+        if let Some((msg, wp, lp)) = queued {
+            write_synthetic_msg_for_hwnd(ctx.cpu, lp_msg, 0, msg, wp, lp)?;
+            return Ok(DispatchOutcome::ReturnedR0(1));
+        }
+        if let Some(outcome) = park_worker_and_retry(ctx)? {
+            return Ok(outcome);
+        }
+    }
     if let Some((hwnd, create_lparam)) = ctx.kernel.pending_create.take() {
         write_synthetic_msg_for_hwnd(ctx.cpu, lp_msg, hwnd, WM_CREATE, 0, create_lparam)?;
         ctx.kernel.synthetic_message_count = count + 1;
@@ -4774,6 +4887,24 @@ fn peek_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
     if budget > 0 && count >= budget {
         write_synthetic_msg(ctx.cpu, lp_msg, WM_QUIT, 0, 0)?;
         return Ok(DispatchOutcome::ReturnedR0(1));
+    }
+    // Worker threads see only what was posted to them; an empty queue
+    // is a yield back to the main thread, not a window message.
+    if let Some(thread_index) = ctx.kernel.current_thread.checked_sub(1) {
+        let queued = ctx.kernel.threads.get_mut(thread_index).and_then(|thread| {
+            if remove_mode & 0x0001 != 0 {
+                thread.messages.pop_front()
+            } else {
+                thread.messages.front().copied()
+            }
+        });
+        if let Some((msg, wp, lp)) = queued {
+            write_synthetic_msg_for_hwnd(ctx.cpu, lp_msg, 0, msg, wp, lp)?;
+            return Ok(DispatchOutcome::ReturnedR0(1));
+        }
+        if let Some(outcome) = park_worker(ctx, 0)? {
+            return Ok(outcome);
+        }
     }
     if let Some((hwnd, create_lparam)) = ctx.kernel.pending_create.take() {
         write_synthetic_msg_for_hwnd(ctx.cpu, lp_msg, hwnd, WM_CREATE, 0, create_lparam)?;
@@ -6370,6 +6501,10 @@ fn create_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
     }
     saved_regs[15] = resume_pc;
     let handle = 0xDEAD_7C00u32.saturating_add(thread_index as u32);
+    // Thread ids start at 2: id 1 is the main thread, and 0 must stay
+    // reserved because `PostThreadMessageW(0, ...)` is what a guest
+    // ends up posting when it never learned a real id.
+    let thread_id = MAIN_THREAD_ID + 1 + thread_index as u32;
     // The creator resumes with the new thread's handle in R0 — that is
     // `CreateThread`'s return value. Without this the guest stores a
     // stale R0 (usually 0) as its thread handle and every later
@@ -6385,10 +6520,19 @@ fn create_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
     let mut thread = GuestThread::new(
         entry, parameter, stack_top, stack_size, exit_va, resume_pc, handle, saved_regs,
     );
+    thread.id = thread_id;
+    // `lpThreadId` is not optional in practice: a game that opens a
+    // waveOut device with `CALLBACK_THREAD` passes the id it read back
+    // here, and leaving the caller's variable untouched made it ask the
+    // driver to notify thread 0.
+    let thread_id_out = ctx.arg_u32(5)?;
+    if thread_id_out != 0 {
+        ctx.cpu.write_mem(thread_id_out, &thread_id.to_le_bytes())?;
+    }
     ctx.cpu.add_code_hook(exit_va)?;
     let suspended = creation_flags & CREATE_SUSPENDED != 0;
     log::debug!(
-        "CreateThread entry=0x{entry:08x} parameter=0x{parameter:08x} stack={} suspended={suspended} -> handle=0x{handle:08x}",
+        "CreateThread entry=0x{entry:08x} parameter=0x{parameter:08x} stack={} suspended={suspended} -> handle=0x{handle:08x} id={thread_id}",
         stack_size,
     );
     if suspended {
@@ -6419,8 +6563,8 @@ fn create_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
     Ok(DispatchOutcome::JumpTo(entry))
 }
 
-fn get_current_thread_id(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
-    Ok(DispatchOutcome::ReturnedR0(1))
+fn get_current_thread_id(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(current_thread_id(ctx)))
 }
 
 // ---------- additional GDI handlers ----------

--- a/crates/pocket-winceapi/src/gx.rs
+++ b/crates/pocket-winceapi/src/gx.rs
@@ -316,6 +316,8 @@ mod tests {
             wave_out_format: GuestFormat::default(),
             wave_out: Default::default(),
             posted_messages: Default::default(),
+            msg_queues: std::collections::HashMap::new(),
+            next_msg_queue_handle: 0xDEAD_E500,
             menus: std::collections::HashMap::new(),
             next_menu_handle: 0xDEAD_2000,
             sub_menus: std::collections::HashMap::new(),

--- a/frontends/pocket-android-jni/src/runner.rs
+++ b/frontends/pocket-android-jni/src/runner.rs
@@ -263,8 +263,14 @@ fn run_game_to_completion(
     emu.mount_dir("\\Application\\", &extracted);
     emu.mount_dir("\\Program Files\\", &extracted);
     emu.mount_dir("\\Program Files\\Game\\", &extracted);
-    if let Some(install_dir) = &entry.install_dir {
-        emu.mount_dir(install_dir, &extracted);
+    if let Some(prefix) = entry.guest_install_prefix() {
+        emu.mount_dir(&prefix, &extracted);
+        // Report the installed path so a game that builds absolute
+        // asset paths off its own module name finds its archive.
+        if let Some(guest_exe) = entry.guest_exe_path() {
+            emu.set_module_path(&guest_exe);
+            emu.set_default_dir(&prefix);
+        }
     }
     // Match the desktop GUI: a real user is in the loop, so don't
     // auto-fire WM_QUIT after a fixed number of synthetic messages.

--- a/frontends/pocket-desktop/src/runner.rs
+++ b/frontends/pocket-desktop/src/runner.rs
@@ -108,6 +108,24 @@ impl Runner {
         let extracted = game.extracted_dir(&library_root);
         emu.mount_dir("\\Application\\", &extracted);
         emu.mount_dir("\\Program Files\\", &extracted);
+        emu.mount_dir("\\Program Files\\Game\\", &extracted);
+        // A game that keeps its assets in one archive opens it by
+        // absolute path built from its own module path -- Spore Origins
+        // asks for `\Program Files\EA\Spore v1.0.4\data.vfs`. Mount the
+        // extracted directory where the cabinet said it would be
+        // installed and report that path from `GetModuleFileNameW`,
+        // the way the CLI already does for a cab. Without it the
+        // archive never opens and the game calls through a pointer it
+        // never stored, which surfaces as READ_UNMAPPED at 0x2.
+        if let Some(prefix) = game.guest_install_prefix() {
+            emu.mount_dir(&prefix, &extracted);
+            summary_lines.push(format!("Mounted {} at {prefix:?}", extracted.display()));
+            if let Some(guest_exe) = game.guest_exe_path() {
+                emu.set_module_path(&guest_exe);
+                emu.set_default_dir(&prefix);
+                summary_lines.push(format!("Module path: {guest_exe}"));
+            }
+        }
         // GUI users actually play the game, so don't auto-fire
         // `WM_QUIT` after a fixed number of synthetic messages —
         // budget=0 means "run until the user stops or the game


### PR DESCRIPTION
## Что сделано

Spore Origins (сборка `spore_SP_GAPI_v1_0_4`) заводилась, но каждый кадр писала `unimplemented call -> COREDLL.dll!ReadMsgQueue` (779 вызовов за прогон) — игра создаёт WinCE point-to-point очередь под power notifications и опрашивает её из главного цикла.

- `pocket-kernel`: очереди сообщений в `KernelState` (`handle -> MsgQueue`: ёмкость, максимальный размер сообщения, FIFO байтовых буферов).
- `pocket-winceapi/coredll`: реализованы `CreateMsgQueue`, `OpenMsgQueue`, `ReadMsgQueue`, `WriteMsgQueue`, `GetMsgQueueInfo`, `CloseMsgQueue` — с разбором `MSGQUEUEOPTIONS` и проверкой флага доступа. Пустая очередь теперь отдаёт `WAIT_TIMEOUT`, а не заглушку.
- `PostThreadMessageW` — поверх существующей FIFO posted-сообщений, с тем же лимитом 256 записей, что у `PostMessageW`.
- `gx`/`coredll`: распознаётся 16-битный `BI_BITFIELDS`-layout, который Spore отдаёт в `CreateDIBSection`, — бэкбуфер корректно трактуется как 565.

## Проверено

- `cargo fmt --all -- --check`, `cargo clippy` (чисто), `cargo test --workspace --lib` — 69 тестов зелёные.
- `pockethle run 15spore_SP_GAPI_v1_0_4.cab --dump-frames-to ...`: игра доходит до экрана настройки звука и продолжает рендерить (frame_counter растёт до 3480+), `ReadMsgQueue` из логов исчез.

## Осталось

- Единственный оставшийся неимплементированный импорт на этом пути — `RequestPowerNotifications`.
- Экран настройки звука пока не реагирует на синтетические тапы (`--tap`), дальше загрузки не идёт — разбираем отдельно.