### PR TITLE
winceapi: fix Zuma crash on gameplay start (nested array ctor iterators)

### DIFF
--- a/crates/pocket-cpu/src/lib.rs
+++ b/crates/pocket-cpu/src/lib.rs
@@ -295,6 +295,42 @@ pub fn dump_mem_around(cpu: &mut dyn Cpu, va: u32, span: u32) -> String {
     }
 }
 
+/// Walk the ARM APCS frame chain from `sp` and format the return
+/// addresses that land inside the loaded image.
+///
+/// Pocket PC compilers emit `mov ip, sp; stmdb sp!, {..., ip, lr, pc}`
+/// prologues, so the saved `LR` slots sit in a predictable spot on the
+/// stack. A crash inside a deeply nested call is almost impossible to
+/// diagnose from `PC` alone -- what matters is which caller passed the
+/// bad pointer down -- so scan the top of the stack and report every
+/// word that looks like a code address in `[image_base, image_end)`.
+pub fn dump_stack_code_addrs(
+    cpu: &mut dyn Cpu,
+    sp: u32,
+    words: u32,
+    image_base: u32,
+    image_end: u32,
+) -> String {
+    let bytes = match cpu.read_mem(sp, words.saturating_mul(4)) {
+        Ok(b) => b,
+        Err(_) => return format!("  <unreadable stack at 0x{sp:08x}>\n"),
+    };
+    let mut out = String::new();
+    out.push_str("  stack return-address candidates (sp first):\n");
+    let mut hits = 0usize;
+    for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+        let v = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        if v >= image_base && v < image_end {
+            out.push_str(&format!("    [sp+0x{:03x}] = 0x{v:08x}\n", (i as u32) * 4));
+            hits += 1;
+        }
+    }
+    if hits == 0 {
+        out.push_str("    <none>\n");
+    }
+    out
+}
+
 pub fn round_up_to_page(size: u32) -> u32 {
     const PAGE: u32 = 0x1000;
     (size + PAGE - 1) & !(PAGE - 1)

--- a/crates/pocket-cpu/src/unicorn.rs
+++ b/crates/pocket-cpu/src/unicorn.rs
@@ -53,6 +53,41 @@ impl UnicornCpu {
                 },
             );
         }
+        if let Ok(spec) = std::env::var("POCKETHLE_WATCH_MEM") {
+            let parse = |t: &str| u64::from_str_radix(t.trim().trim_start_matches("0x"), 16).ok();
+            let want_value = std::env::var("POCKETHLE_WATCH_VAL")
+                .ok()
+                .and_then(|v| parse(&v));
+            for token in spec.split(',') {
+                let (lo, hi) = match token.split_once('-') {
+                    Some((a, b)) => match (parse(a), parse(b)) {
+                        (Some(a), Some(b)) => (a, b),
+                        _ => continue,
+                    },
+                    None => match parse(token) {
+                        Some(a) => (a, a + 3),
+                        None => continue,
+                    },
+                };
+                let _ = uc.add_mem_hook(
+                    ::unicorn_engine::unicorn_const::HookType::MEM_WRITE,
+                    lo,
+                    hi,
+                    move |uc, _kind, a, size, value| {
+                        if let Some(want) = want_value {
+                            if value as u64 != want {
+                                return true;
+                            }
+                        }
+                        let pc = uc.reg_read(RegisterARM::PC).unwrap_or(0);
+                        eprintln!(
+                            "[watch-mem] write 0x{a:08x} size={size} value=0x{value:08x} pc=0x{pc:08x}"
+                        );
+                        true
+                    },
+                );
+            }
+        }
         Ok(Self {
             uc,
             arch,

--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -23,7 +23,10 @@ use byteorder::{ByteOrder, LittleEndian};
 use indexmap::IndexMap;
 use thiserror::Error;
 
-use pocket_cpu::{dump_mem_around, dump_regs, regs::ArmReg, Arch, Cpu, CpuError, Prot, StopReason};
+use pocket_cpu::{
+    dump_mem_around, dump_regs, dump_stack_code_addrs, regs::ArmReg, Arch, Cpu, CpuError, Prot,
+    StopReason,
+};
 use pocket_pe::{machine, ImportBinding, ImportSymbol, LoadedImage, ResourceEntry};
 
 pub mod audio;
@@ -540,12 +543,18 @@ pub struct KernelState {
     /// `JumpTo` round-trip: the handler stashes the iteration state
     /// here, sets `LR = ??_L thunk_va` and `JumpTo = pCtor`, and the
     /// guest's `bx lr` brings us back to the same handler for the
-    /// next iteration. The map is keyed by the iterator's own
-    /// `thunk_va` so a nested `??_L` from inside a ctor doesn't
-    /// collide with the outer one.
-    pub vector_iter_frames: HashMap<u32, VectorIterFrame>,
+    /// next iteration.
+    ///
+    /// Element constructors regularly start their own array —
+    /// Zuma's board holds two sub-boards that each hold 200 balls —
+    /// so `??_L` re-enters itself while an outer iteration is still
+    /// in flight. The in-flight iterations therefore form a stack,
+    /// with the innermost one on top; see
+    /// [`VectorIterFrame::sp_at_call`] for how a nested call is told
+    /// apart from a callback returning into the thunk.
+    pub vector_iter_stack: Vec<VectorIterFrame>,
     /// In-flight `qsort` calls, keyed the same way as
-    /// [`Self::vector_iter_frames`]. `qsort`'s comparison function
+    /// [`Self::vector_iter_stack`]. `qsort`'s comparison function
     /// also lives in guest code, so the sort has to be driven one
     /// comparison per `JumpTo` round-trip — see [`QsortFrame`].
     pub qsort_frames: HashMap<u32, QsortFrame>,
@@ -727,6 +736,16 @@ pub struct VectorIterFrame {
     /// once every element has been processed. Restored into LR on
     /// the final iteration's `ReturnedR0`.
     pub saved_lr: u32,
+    /// Thunk this iteration is running on. `??_L` and `??_M` are
+    /// separate imports with separate thunks, and both can be live
+    /// at once.
+    pub thunk_va: u32,
+    /// Guest SP when the iterator was called. The per-element
+    /// callback is entered with this exact SP and restores it before
+    /// branching back to the thunk, so a re-entry whose SP still
+    /// matches is that callback returning, while a lower SP means
+    /// the callback has started a nested array of its own.
+    pub sp_at_call: u32,
 }
 
 /// One IAT entry that has been resolved to a host-side stub.
@@ -1218,7 +1237,7 @@ impl Process {
                 pressed_keys: [false; 256],
                 should_stop: false,
                 tls_slots_used: 0,
-                vector_iter_frames: HashMap::new(),
+                vector_iter_stack: Vec::new(),
                 qsort_frames: HashMap::new(),
                 security_cookie: 0,
                 audio: AudioEngine::new(),
@@ -1429,10 +1448,14 @@ pub fn run_main_loop_with_hook(
             Ok(s) => s,
             Err(e) => {
                 let pc_now = cpu.read_reg(ArmReg::Pc).unwrap_or(pc);
+                let sp_now = cpu.read_reg(ArmReg::Sp).unwrap_or(0);
+                let image_base = process.image.image_base;
+                let image_end = image_base.saturating_add(process.image.size_of_image);
                 log::error!(
-                        "cpu crashed: {e}\n  last requested pc=0x{pc:08x}, current pc=0x{pc_now:08x}\n{regs}{mem}",
+                        "cpu crashed: {e}\n  last requested pc=0x{pc:08x}, current pc=0x{pc_now:08x}\n{regs}{mem}{stack}",
                         regs = dump_regs(cpu),
                         mem = dump_mem_around(cpu, pc_now, 16),
+                        stack = dump_stack_code_addrs(cpu, sp_now, 64, image_base, image_end),
                     );
                 return Err(e.into());
             }

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -988,7 +988,7 @@ pub(crate) fn null_returning(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, 
 // because the per-element function pointer lives in *guest* code, so
 // we drive the loop one element per `JumpTo` round-trip: the handler
 // stashes `(p_begin, cb_element, n_elements, p_func, i, saved_lr)` in
-// `KernelState::vector_iter_frames`, sets `R0 = element pointer`,
+// `KernelState::vector_iter_stack`, sets `R0 = element pointer`,
 // `LR = ??_L thunk_va`, and trampolines into `pCtor`. When `pCtor`
 // returns it `bx lr`s back to our thunk, the dispatcher fires us
 // again, and we either advance `i` for the next element or — once
@@ -1004,48 +1004,81 @@ fn vector_dtor_iterator(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kernel
 
 fn drive_vector_iter(ctx: &mut CallCtx<'_>, is_dtor: bool) -> Result<DispatchOutcome, KernelError> {
     let thunk_va = ctx.thunk.thunk_va;
-    let frame = match ctx.kernel.vector_iter_frames.get(&thunk_va).copied() {
-        Some(mut f) => {
-            // Re-entry: the previous element's ctor / dtor just `bx
-            // lr`'d back to our thunk. Move on to the next one.
-            f.i = f.i.saturating_add(1);
-            f
-        }
-        None => {
-            // First entry: capture the args. Order matches the MSVC
-            // prototype above.
-            let p_begin = ctx.arg_u32(0)?;
-            let cb_element = ctx.arg_u32(1)?;
-            let n_elements = ctx.arg_u32(2)? as i32;
-            let p_func = ctx.arg_u32(3)?;
-            // `pCleanupCtor` is the 5th argument and lives at
-            // `[sp+0]` per AAPCS. Only `??_L` actually has it, but
-            // reading past the end on `??_M` is harmless (the value
-            // is unused) and saves a branch here.
-            let p_cleanup = ctx.arg_u32(4).unwrap_or(0);
-            let saved_lr = ctx.cpu.read_reg(ArmReg::Lr)?;
-            log::trace!(
-                "{} begin: pBegin=0x{:08x} cb={} N={} pFunc=0x{:08x} cleanup=0x{:08x} retLR=0x{:08x}",
-                ctx.thunk.label(),
-                p_begin,
-                cb_element,
-                n_elements,
-                p_func,
-                p_cleanup,
-                saved_lr,
-            );
-            VectorIterFrame {
-                p_begin,
-                cb_element,
-                n_elements,
-                p_func,
-                p_cleanup,
-                is_dtor,
-                i: 0,
-                saved_lr,
-            }
-        }
-    };
+    let sp_now = ctx.cpu.read_reg(ArmReg::Sp)?;
+
+    // Iterations whose callback can no longer return — the guest
+    // unwound past their frame, e.g. through a C++ exception — would
+    // otherwise sit on the stack forever and swallow a later call.
+    while ctx
+        .kernel
+        .vector_iter_stack
+        .last()
+        .is_some_and(|f| f.sp_at_call < sp_now)
+    {
+        ctx.kernel.vector_iter_stack.pop();
+    }
+
+    // Tell "the element callback just branched back to us" apart from
+    // "the element callback started an array of its own". The former
+    // re-enters with the SP the callback was entered with; the latter
+    // is a fresh `bl` from inside the callback's own frame, so its SP
+    // is lower.
+    let resuming = ctx
+        .kernel
+        .vector_iter_stack
+        .last()
+        .is_some_and(|f| f.thunk_va == thunk_va && f.sp_at_call == sp_now);
+
+    if resuming {
+        let frame = ctx
+            .kernel
+            .vector_iter_stack
+            .last_mut()
+            .expect("stack is non-empty when resuming");
+        frame.i = frame.i.saturating_add(1);
+    } else {
+        // First entry: capture the args. Order matches the MSVC
+        // prototype above.
+        let p_begin = ctx.arg_u32(0)?;
+        let cb_element = ctx.arg_u32(1)?;
+        let n_elements = ctx.arg_u32(2)? as i32;
+        let p_func = ctx.arg_u32(3)?;
+        // `pCleanupCtor` is the 5th argument and lives at
+        // `[sp+0]` per AAPCS. Only `??_L` actually has it, but
+        // reading past the end on `??_M` is harmless (the value
+        // is unused) and saves a branch here.
+        let p_cleanup = ctx.arg_u32(4).unwrap_or(0);
+        let saved_lr = ctx.cpu.read_reg(ArmReg::Lr)?;
+        log::trace!(
+            "{} begin: pBegin=0x{:08x} cb={} N={} pFunc=0x{:08x} cleanup=0x{:08x} retLR=0x{:08x} depth={}",
+            ctx.thunk.label(),
+            p_begin,
+            cb_element,
+            n_elements,
+            p_func,
+            p_cleanup,
+            saved_lr,
+            ctx.kernel.vector_iter_stack.len() + 1,
+        );
+        ctx.kernel.vector_iter_stack.push(VectorIterFrame {
+            p_begin,
+            cb_element,
+            n_elements,
+            p_func,
+            p_cleanup,
+            is_dtor,
+            i: 0,
+            saved_lr,
+            thunk_va,
+            sp_at_call: sp_now,
+        });
+    }
+
+    let frame = *ctx
+        .kernel
+        .vector_iter_stack
+        .last()
+        .expect("a frame was just pushed or resumed");
 
     // Termination conditions:
     //   * `n_elements <= 0` — empty array, nothing to do.
@@ -1055,7 +1088,7 @@ fn drive_vector_iter(ctx: &mut CallCtx<'_>, is_dtor: bool) -> Result<DispatchOut
     //     call. We treat it as "no-op iteration" and return cleanly
     //     so the rest of the program isn't poisoned.
     if frame.n_elements <= 0 || frame.i >= frame.n_elements || frame.p_func == 0 {
-        ctx.kernel.vector_iter_frames.remove(&thunk_va);
+        ctx.kernel.vector_iter_stack.pop();
         ctx.cpu.write_reg(ArmReg::Lr, frame.saved_lr)?;
         // Real prototype is `void`-returning. Return 0 in R0 just so
         // the dispatcher has a defined value; callers ignore it.
@@ -1088,9 +1121,7 @@ fn drive_vector_iter(ctx: &mut CallCtx<'_>, is_dtor: bool) -> Result<DispatchOut
     // Set LR so that pFunc's `bx lr` brings the CPU straight back
     // into our own thunk for the next step.
     ctx.cpu.write_reg(ArmReg::Lr, thunk_va)?;
-    let target = frame.p_func;
-    ctx.kernel.vector_iter_frames.insert(thunk_va, frame);
-    Ok(DispatchOutcome::JumpTo(target))
+    Ok(DispatchOutcome::JumpTo(frame.p_func))
 }
 
 // ---------- qsort ----------
@@ -4011,6 +4042,10 @@ fn do_alloc(ctx: &mut CallCtx<'_>, size: u32) -> Result<DispatchOutcome, KernelE
     if size > 0 {
         let zeros = vec![0u8; size as usize];
         ctx.cpu.write_mem(user_ptr, &zeros)?;
+    }
+    if std::env::var("POCKETHLE_TRACE_ALLOC").is_ok() && size >= 0x1000 {
+        let lr = ctx.cpu.read_reg(pocket_cpu::regs::ArmReg::Lr).unwrap_or(0);
+        eprintln!("[trace-alloc] ptr=0x{user_ptr:08x} size=0x{size:08x} lr=0x{lr:08x}");
     }
     Ok(DispatchOutcome::ReturnedR0(user_ptr))
 }
@@ -9608,7 +9643,7 @@ mod tests {
             pressed_keys: [false; 256],
             should_stop: false,
             tls_slots_used: 0,
-            vector_iter_frames: std::collections::HashMap::new(),
+            vector_iter_stack: Vec::new(),
             qsort_frames: std::collections::HashMap::new(),
             security_cookie: 0,
             audio: AudioEngine::new(),
@@ -9701,6 +9736,103 @@ mod tests {
         // element, so nowhere near the O(n^2) a linear scan would need.
         assert!(comparisons <= 8 * 3, "too many round-trips: {comparisons}");
         assert!(kernel.qsort_frames.is_empty());
+    }
+
+    /// Zuma's `Board` ctor runs `??_L` over two sub-objects, and each
+    /// sub-object's ctor runs `??_L` again over its own 200-element
+    /// array. The iterator state therefore has to nest: the inner run
+    /// must not be mistaken for "the outer element's ctor returned",
+    /// which used to corrupt the outer loop and hand the guest a bogus
+    /// `this`.
+    #[test]
+    fn vector_ctor_iterator_nests() {
+        const OUTER_BEGIN: u32 = 0x2000;
+        const OUTER_STRIDE: u32 = 0x100;
+        const INNER_STRIDE: u32 = 8;
+        const OUTER_CTOR: u32 = 0x4000;
+        const INNER_CTOR: u32 = 0x5000;
+        const OUTER_SP: u32 = 0x7800;
+        const INNER_SP: u32 = 0x7700;
+        const OUTER_LR: u32 = 0xDEAD_BEEF;
+
+        let mut cpu = StubCpu::new();
+        let mut kernel = fresh_kernel();
+        cpu.map_region(0x7000, 0x1000, Prot::READ | Prot::WRITE)
+            .unwrap();
+
+        let begin_outer = |cpu: &mut StubCpu| {
+            cpu.write_reg(ArmReg::R0, OUTER_BEGIN).unwrap();
+            cpu.write_reg(ArmReg::R1, OUTER_STRIDE).unwrap();
+            cpu.write_reg(ArmReg::R2, 2).unwrap();
+            cpu.write_reg(ArmReg::R3, OUTER_CTOR).unwrap();
+            cpu.write_reg(ArmReg::Sp, OUTER_SP).unwrap();
+            cpu.write_reg(ArmReg::Lr, OUTER_LR).unwrap();
+        };
+        begin_outer(&mut cpu);
+
+        let t = dummy_thunk();
+        let mut outer_elems: Vec<u32> = Vec::new();
+        let mut inner_elems: Vec<u32> = Vec::new();
+        // `true` while the inner iterator owns the round-trips.
+        let mut in_inner = false;
+        let mut steps = 0;
+        loop {
+            steps += 1;
+            assert!(steps < 100, "state machine is not terminating");
+            let outcome = {
+                let mut c = CallCtx {
+                    cpu: &mut cpu,
+                    thunk: &t,
+                    kernel: &mut kernel,
+                };
+                vector_ctor_iterator(&mut c).unwrap()
+            };
+            match outcome {
+                DispatchOutcome::JumpTo(OUTER_CTOR) => {
+                    let elem = cpu.read_reg(ArmReg::R0).unwrap();
+                    outer_elems.push(elem);
+                    // The element ctor immediately starts its own
+                    // nested iteration, one frame deeper on the stack.
+                    cpu.write_reg(ArmReg::R0, elem + 0x10).unwrap();
+                    cpu.write_reg(ArmReg::R1, INNER_STRIDE).unwrap();
+                    cpu.write_reg(ArmReg::R2, 3).unwrap();
+                    cpu.write_reg(ArmReg::R3, INNER_CTOR).unwrap();
+                    cpu.write_reg(ArmReg::Sp, INNER_SP).unwrap();
+                    cpu.write_reg(ArmReg::Lr, 0x4100).unwrap();
+                    in_inner = true;
+                }
+                DispatchOutcome::JumpTo(INNER_CTOR) => {
+                    inner_elems.push(cpu.read_reg(ArmReg::R0).unwrap());
+                    // Inner element ctor returns: same SP as its call.
+                    cpu.write_reg(ArmReg::Sp, INNER_SP).unwrap();
+                }
+                DispatchOutcome::JumpTo(other) => panic!("unexpected target 0x{other:08x}"),
+                DispatchOutcome::ReturnedR0(_) if in_inner => {
+                    // Inner iteration done, so the outer element's ctor
+                    // now returns to the outer iterator's thunk.
+                    assert_eq!(cpu.read_reg(ArmReg::Lr).unwrap(), 0x4100);
+                    in_inner = false;
+                    cpu.write_reg(ArmReg::Sp, OUTER_SP).unwrap();
+                }
+                DispatchOutcome::ReturnedR0(_) => break,
+                other => panic!("unexpected outcome {other:?}"),
+            }
+        }
+
+        assert_eq!(outer_elems, vec![OUTER_BEGIN, OUTER_BEGIN + OUTER_STRIDE]);
+        assert_eq!(
+            inner_elems,
+            vec![
+                OUTER_BEGIN + 0x10,
+                OUTER_BEGIN + 0x18,
+                OUTER_BEGIN + 0x20,
+                OUTER_BEGIN + OUTER_STRIDE + 0x10,
+                OUTER_BEGIN + OUTER_STRIDE + 0x18,
+                OUTER_BEGIN + OUTER_STRIDE + 0x20,
+            ]
+        );
+        assert_eq!(cpu.read_reg(ArmReg::Lr).unwrap(), OUTER_LR);
+        assert!(kernel.vector_iter_stack.is_empty());
     }
 
     #[test]

--- a/crates/pocket-winceapi/src/gx.rs
+++ b/crates/pocket-winceapi/src/gx.rs
@@ -309,7 +309,7 @@ mod tests {
             pressed_keys: [false; 256],
             should_stop: false,
             tls_slots_used: 0,
-            vector_iter_frames: std::collections::HashMap::new(),
+            vector_iter_stack: Vec::new(),
             qsort_frames: std::collections::HashMap::new(),
             security_cookie: 0,
             audio: AudioEngine::new(),


### PR DESCRIPTION
Zuma crashed with `READ_UNMAPPED ... at guest address 0x00001ce8` the moment a level started (Adventure -> Play -> OK). It now reaches gameplay and keeps animating.

## Root cause

MSVC's array construction helpers `??_L` / `??_M` (`vector constructor/destructor iterator`) are imported from coredll, so PocketHLE drives them one element per `JumpTo` round-trip. The state was kept as one frame per thunk VA.

Zuma nests them:

- `Board::Board` calls `??_L(board+0x180, 0x4804, 2, subBoardCtor, subBoardDtor)`
- `subBoardCtor` calls `??_L(this, 0x5c, 0xc8, ballCtor, ballDtor)` for its 200 balls

The inner call hit the same thunk, so it was mistaken for "the outer element ctor returned": the outer index advanced, the 200 balls were never constructed, and the outer iterator resumed the Board constructor with the wrong element pointer. The constructor then read `this->mApp` out of an object that was really the second sub-board, got `NULL`, and dereferenced `NULL + 0x1ce8`.

## Fix

Keep a stack of iterator frames. A callback return is distinguished from a nested call by the guest SP: an element ctor always returns to the thunk with SP back at the value it had when we jumped in, while a nested call is necessarily deeper. Frames whose SP is already above the current one (guest unwound past them) are pruned on entry.

Covered by `vector_ctor_iterator_drives_nested_arrays`, which drives an outer 2-element array whose ctor opens a nested 3-element array and asserts every element pointer, the LR restore and an empty frame stack.

## Also included

Crash triage tooling used to find this:

- the CPU crash dump walks the stack for code addresses, giving a call chain without a debugger
- `POCKETHLE_WATCH_MEM=<addr|start-end>` (+ optional `POCKETHLE_WATCH_VAL=<word>`) logs guest writes with the faulting PC
- `POCKETHLE_TRACE_ALLOC=1` logs heap allocations with size and LR

## Testing

- `cargo test --workspace --no-default-features --lib` — green, `cargo fmt --check` and `cargo clippy` clean
- Zuma: 400 frames through Adventure -> Play -> OK, no crash, board/track/frog rendering and animating
- Regression: Spore Origins, Bejeweled 1, Bejeweled 2 and Asphalt 2 3D still boot; Asphalt's first frame is byte-identical to before the change
