### PR TITLE
fix: satisfy rustfmt and clippy checks

### DIFF
--- a/crates/pocket-kernel/src/audio.rs
+++ b/crates/pocket-kernel/src/audio.rs
@@ -479,9 +479,9 @@ impl AudioEngine {
         {
             if let Ok(mut s) = self.shared.lock() {
                 s.add_voice(samples.to_vec(), format, looped);
-                return samples.len();
+                samples.len()
             } else {
-                return 0;
+                0
             }
         }
         #[cfg(not(feature = "audio-cpal"))]

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -6495,7 +6495,9 @@ fn submit_wave_bytes(
             .collect(),
         _ => return Ok(false),
     };
-    ctx.kernel.audio.play_voice(&samples, fmt, flags & 0x0008 != 0);
+    ctx.kernel
+        .audio
+        .play_voice(&samples, fmt, flags & 0x0008 != 0);
     ctx.kernel.audio.start();
     Ok(true)
 }


### PR DESCRIPTION
Исправляет падения CI:

- форматирует цепочку вызова `AudioEngine::play_voice` по rustfmt;
- убирает лишние `return` в `play_voice`, чтобы clippy с `-D warnings` проходил.

Локально проверено:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`