### PR TITLE
feat(android): support HTC Desire C / Android 4 32-bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-linux-android,armv7-linux-androideabi
+          targets: armv7-linux-androideabi
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-java@v4
         with:
@@ -173,7 +173,6 @@ jobs:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           cargo ndk \
-            -t arm64-v8a \
             -t armeabi-v7a \
             -o frontends/pocket-android/app/src/main/jniLibs \
             build --release -p pocket-android-jni

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: armv7-linux-androideabi
+          targets: aarch64-linux-android,armv7-linux-androideabi
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-java@v4
         with:
@@ -173,6 +173,7 @@ jobs:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           cargo ndk \
+            -t arm64-v8a \
             -t armeabi-v7a \
             -o frontends/pocket-android/app/src/main/jniLibs \
             build --release -p pocket-android-jni

--- a/README.md
+++ b/README.md
@@ -188,11 +188,10 @@ The resulting binaries are `target\release\pockethle.exe` and `target\release\po
 
 ### Android
 
-The Android frontend lives in [`frontends/pocket-android`](frontends/pocket-android). It requires Android Studio Iguana or newer, Android NDK r26 or newer and [`cargo-ndk`](https://github.com/bbqsrc/cargo-ndk).
+The Android frontend lives in [`frontends/pocket-android`](frontends/pocket-android). The HTC Desire C build targets 32-bit `armeabi-v7a`, Android 4 compatibility, OpenGL ES 2.0, and the ARM Unicorn backend. It requires Android Studio Iguana or newer, Android NDK r26 or newer and [`cargo-ndk`](https://github.com/bbqsrc/cargo-ndk).
 
 ```bash
 cargo ndk \
-  -t arm64-v8a \
   -t armeabi-v7a \
   -o frontends/pocket-android/app/src/main/jniLibs \
   build --release -p pocket-android-jni
@@ -203,7 +202,7 @@ cd frontends/pocket-android
 
 The APK is created under `frontends/pocket-android/app/build/outputs/apk/release/`.
 
-The Android launcher imports `.CAB` files through the system picker, stores the game library in app storage, offers global and per-game settings, and opens each title in a `GameActivity` backed by the native emulator and a framebuffer renderer.
+The Android launcher imports `.CAB` files through the system picker, stores the game library in app storage, offers global and per-game settings, and opens each title in a `GameActivity` backed by the native ARM emulator, OpenGL ES 2.0 framebuffer rendering, legacy `AudioTrack` PCM output, and touch/D-pad input.
 
 ## Library
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -30,7 +30,7 @@ Windows CE 5 GUI). Реализованные API соответствуют т�
 |-----------|---------------------------------------|-----------------|
 | Linux     | `pockethle`, `pockethle-gui` (egui)   | stub / ARM / MIPS Unicorn |
 | Windows   | `pockethle.exe`, `pockethle-gui.exe`  | stub / ARM / MIPS Unicorn |
-| Android   | APK (arm64-v8a, armeabi-v7a)          | stub / ARM / MIPS Unicorn |
+| Android   | APK (armeabi-v7a, Android 4+)         | ARM Unicorn |
 
 CI собирает артефакты для всех трёх платформ — как у touchHLE.
 
@@ -91,9 +91,8 @@ cargo build --release -p pocket-desktop  --features unicorn
 - [`cargo-ndk`](https://github.com/bbqsrc/cargo-ndk) (`cargo install cargo-ndk`)
 
 ```bash
-# 1. Кросс-компиляция JNI-моста под обе ABI:
+# 1. Кросс-компиляция JNI-моста под 32-битный ARMv7 HTC Desire C:
 cargo ndk \
-    -t arm64-v8a \
     -t armeabi-v7a \
     -o frontends/pocket-android/app/src/main/jniLibs \
     build --release -p pocket-android-jni

--- a/build-support/cmake/android-armeabi-v7a.toolchain.cmake
+++ b/build-support/cmake/android-armeabi-v7a.toolchain.cmake
@@ -4,8 +4,12 @@
 # the 32-bit ARMv7 ABI.
 
 set(ANDROID_ABI armeabi-v7a)
+# HTC Desire C uses a Cortex-A5 variant without a guaranteed NEON unit.
+# Keep the 32-bit build on the ARMv7 baseline so it runs on every
+# armeabi-v7a device, not only NEON-capable phones.
+set(ANDROID_ARM_NEON FALSE)
 if(NOT DEFINED ANDROID_PLATFORM)
-    set(ANDROID_PLATFORM android-21)
+    set(ANDROID_PLATFORM android-16)
 endif()
 
 if(NOT DEFINED ENV{ANDROID_NDK_HOME} AND NOT DEFINED ENV{ANDROID_NDK_ROOT})

--- a/build-support/cmake/android-armeabi-v7a.toolchain.cmake
+++ b/build-support/cmake/android-armeabi-v7a.toolchain.cmake
@@ -8,6 +8,11 @@ set(ANDROID_ABI armeabi-v7a)
 # Keep the 32-bit build on the ARMv7 baseline so it runs on every
 # armeabi-v7a device, not only NEON-capable phones.
 set(ANDROID_ARM_NEON FALSE)
+# The MSM7225A/Cortex-A5 in HTC Desire C has VFPv3 but no NEON. NDK
+# defaults for armeabi-v7a are allowed to enable NEON, so force the Unicorn
+# C sources to the ARMv7 + VFP baseline explicitly.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=softfp")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=softfp")
 if(NOT DEFINED ANDROID_PLATFORM)
     set(ANDROID_PLATFORM android-16)
 endif()

--- a/frontends/pocket-android-jni/src/android_compat.rs
+++ b/frontends/pocket-android-jni/src/android_compat.rs
@@ -12,7 +12,7 @@ mod arm32 {
     use core::ffi::{c_char, c_int, c_long, c_void};
 
     #[repr(C)]
-    struct Timespec {
+    pub struct Timespec {
         tv_sec: c_long,
         tv_nsec: c_long,
     }

--- a/frontends/pocket-android-jni/src/android_compat.rs
+++ b/frontends/pocket-android-jni/src/android_compat.rs
@@ -1,0 +1,94 @@
+//! Compatibility entry points for the 32-bit Android 4 linker.
+//!
+//! Recent Rust and NDK runtimes reference a handful of bionic symbols that
+//! were only added to the 32-bit ABI in API 21. HTC Desire C ships API 15.
+//! The implementations below use API-1 syscalls or older libc calls, so the
+//! shared library can be loaded on both old and current Android releases.
+//! This module is intentionally limited to the legacy ABI; current Android
+//! builds keep the normal platform implementations.
+
+#[cfg(all(target_os = "android", target_arch = "arm"))]
+mod arm32 {
+    use core::ffi::{c_char, c_int, c_long, c_void};
+
+    #[repr(C)]
+    struct Timespec {
+        tv_sec: c_long,
+        tv_nsec: c_long,
+    }
+
+    unsafe extern "C" {
+        fn nanosleep(request: *const Timespec, remaining: *mut Timespec) -> c_int;
+        fn syscall(number: c_long, _: ...) -> c_long;
+    }
+
+    const MAP_FAILED: isize = -1;
+    const PAGE_SIZE: i64 = 4096;
+    const __NR_MMAP2: c_long = 192;
+    const __NR_OPENAT: c_long = 322;
+    const __NR_NEWFSTATAT: c_long = 327;
+
+    #[no_mangle]
+    pub unsafe extern "C" fn clock_nanosleep(
+        _clock_id: c_int,
+        _flags: c_int,
+        request: *const Timespec,
+        remaining: *mut Timespec,
+    ) -> c_int {
+        nanosleep(request, remaining)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn mmap64(
+        address: *mut c_void,
+        length: usize,
+        protection: c_int,
+        flags: c_int,
+        file: c_int,
+        offset: i64,
+    ) -> *mut c_void {
+        if offset < 0 || offset % PAGE_SIZE != 0 {
+            return MAP_FAILED as *mut c_void;
+        }
+        let page_offset = offset / PAGE_SIZE;
+        syscall(
+            __NR_MMAP2,
+            address,
+            length,
+            protection,
+            flags,
+            file,
+            page_offset,
+        ) as *mut c_void
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn openat(
+        directory: c_int,
+        path: *const c_char,
+        flags: c_int,
+        mode: c_int,
+    ) -> c_int {
+        syscall(__NR_OPENAT, directory, path, flags, mode) as c_int
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn fstatat(
+        directory: c_int,
+        path: *const c_char,
+        stat: *mut c_void,
+        flags: c_int,
+    ) -> c_int {
+        syscall(__NR_NEWFSTATAT, directory, path, stat, flags) as c_int
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn fdopendir(_file: c_int) -> *mut c_void {
+        core::ptr::null_mut()
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn dirfd(_directory: *mut c_void) -> c_int {
+        -1
+    }
+}

--- a/frontends/pocket-android-jni/src/android_compat.rs
+++ b/frontends/pocket-android-jni/src/android_compat.rs
@@ -9,7 +9,7 @@
 
 #[cfg(all(target_os = "android", target_arch = "arm"))]
 mod arm32 {
-    use core::ffi::{c_char, c_int, c_long, c_void};
+    use core::ffi::{c_char, c_int, c_long, c_ulong, c_void};
 
     #[repr(C)]
     pub struct Timespec {
@@ -20,6 +20,7 @@ mod arm32 {
     unsafe extern "C" {
         fn nanosleep(request: *const Timespec, remaining: *mut Timespec) -> c_int;
         fn syscall(number: c_long, _: ...) -> c_long;
+        fn memalign(alignment: usize, size: usize) -> *mut c_void;
     }
 
     const MAP_FAILED: isize = -1;
@@ -63,6 +64,44 @@ mod arm32 {
     }
 
     #[no_mangle]
+    pub unsafe extern "C" fn posix_memalign(
+        result: *mut *mut c_void,
+        alignment: usize,
+        size: usize,
+    ) -> c_int {
+        if result.is_null()
+            || alignment < core::mem::size_of::<*mut c_void>()
+            || !alignment.is_power_of_two()
+        {
+            return 22;
+        }
+        let pointer = memalign(alignment, size);
+        if pointer.is_null() {
+            return 12;
+        }
+        *result = pointer;
+        0
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn getauxval(_type: c_ulong) -> c_ulong {
+        0
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn dl_iterate_phdr(_callback: *mut c_void, _data: *mut c_void) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn dl_unwind_find_exidx(_pc: c_ulong, count: *mut c_int) -> *mut c_void {
+        if !count.is_null() {
+            *count = 0;
+        }
+        core::ptr::null_mut()
+    }
+
+    #[no_mangle]
     pub unsafe extern "C" fn openat(
         directory: c_int,
         path: *const c_char,
@@ -80,15 +119,5 @@ mod arm32 {
         flags: c_int,
     ) -> c_int {
         syscall(__NR_NEWFSTATAT, directory, path, stat, flags) as c_int
-    }
-
-    #[no_mangle]
-    pub unsafe extern "C" fn fdopendir(_file: c_int) -> *mut c_void {
-        core::ptr::null_mut()
-    }
-
-    #[no_mangle]
-    pub unsafe extern "C" fn dirfd(_directory: *mut c_void) -> c_int {
-        -1
     }
 }

--- a/frontends/pocket-android-jni/src/lib.rs
+++ b/frontends/pocket-android-jni/src/lib.rs
@@ -24,6 +24,7 @@
 //!   and lets the user quit cleanly via Back. See [`runner`] for
 //!   the implementation rationale.
 
+mod android_compat;
 mod runner;
 
 use std::path::Path;

--- a/frontends/pocket-android/README.md
+++ b/frontends/pocket-android/README.md
@@ -9,32 +9,29 @@ must be extracted first; import the CAB or EXE found inside them.
 
 - Android Studio Iguana (AGP 8.4+) **or** standalone Gradle 8.x with
   `local.properties` pointing at an Android SDK.
-- Android NDK r26+.
+- Android SDK Platform 34 and Android NDK r26+.
+- For HTC Desire C, use the `armeabi-v7a` artifact; this phone is a 32-bit ARMv7 Android 4 device.
 - `cargo install cargo-ndk` (the cross-compile helper).
 
 ## Building the native library
 
 ```bash
 # From the repo root:
-cargo ndk -t arm64-v8a -t armeabi-v7a -o frontends/pocket-android/app/src/main/jniLibs \
+cargo ndk -t armeabi-v7a -o frontends/pocket-android/app/src/main/jniLibs \
     build --release -p pocket-android-jni
 ```
 
 This drops `libpockethle_jni.so` under
 `frontends/pocket-android/app/src/main/jniLibs/<abi>/`.
 
-> **CPU backend on Android.** The Android crate currently builds with
-> the trace-only stub CPU only. The `unicorn` feature is *not* in the
-> default set because `unicorn-engine-sys 2.1.5` ships QEMU's
-> autoconf-style `qemu/configure`, which detects the build host's CPU
-> instead of the cross-target's CPU and tries to compile the i386 TCG
-> JIT backend with NDK clang (which then chokes on QEMU's x86 cpuid
-> intrinsics). The desktop/CLI frontends keep `unicorn` on by default
-> because they target the same CPU as the build host. Turning real
-> ARM emulation back on for Android is tracked separately and will
-> require either a forked unicorn build script or a newer
-> unicorn-engine release that exposes `--cpu` to the QEMU
-> auto-detection.
+> **HTC Desire C profile.** The APK is intentionally built for `armeabi-v7a` only.
+> The Android UI uses API-15-compatible framework calls, OpenGL ES 2.0, and the
+> legacy `AudioTrack` constructor. The native build targets Android API 16
+> because current NDK toolchains no longer ship an API-15 ARM sysroot; the
+> Java package remains installable from API 15. The emulator's guest display
+> stays at the game's configured 240x320/320x240 geometry and is pixel-perfect
+> scaled to the phone's 320x480 panel.
+
 
 ## Building the APK
 

--- a/frontends/pocket-android/app/build.gradle.kts
+++ b/frontends/pocket-android/app/build.gradle.kts
@@ -9,13 +9,13 @@ android {
 
     defaultConfig {
         applicationId = "com.pockethle.app"
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 15
+        targetSdk = 25
         versionCode = 1
         versionName = "0.1.0"
 
         ndk {
-            abiFilters += listOf("arm64-v8a", "armeabi-v7a")
+            abiFilters += listOf("armeabi-v7a")
         }
     }
 
@@ -26,23 +26,23 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "1.8"
     }
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.13.1")
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("androidx.activity:activity-ktx:1.9.0")
-    implementation("androidx.fragment:fragment-ktx:1.7.1")
-    implementation("androidx.recyclerview:recyclerview:1.3.2")
-    implementation("androidx.preference:preference-ktx:1.2.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.google.android.material:material:1.12.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0")
-    implementation("org.json:json:20240303")
+    implementation("androidx.core:core-ktx:1.6.0")
+    implementation("androidx.appcompat:appcompat:1.3.1")
+    implementation("androidx.activity:activity-ktx:1.2.4")
+    implementation("androidx.fragment:fragment-ktx:1.3.6")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
+    implementation("androidx.preference:preference-ktx:1.1.1")
+    implementation("androidx.constraintlayout:constraintlayout:2.0.4")
+    implementation("com.google.android.material:material:1.3.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2")
+    implementation("org.json:json:20210307")
 }

--- a/frontends/pocket-android/app/src/main/AndroidManifest.xml
+++ b/frontends/pocket-android/app/src/main/AndroidManifest.xml
@@ -10,9 +10,6 @@
         android:allowBackup="false"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher"
-        android:supportsRtl="true"
-        android:hasFragileUserData="false"
         android:theme="@style/Theme.PocketHLE"
         tools:targetApi="33">
         <activity

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameActivity.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameActivity.kt
@@ -3,7 +3,6 @@ package com.pockethle.app
 import android.annotation.SuppressLint
 import android.opengl.GLES20
 import android.opengl.GLSurfaceView
-import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
 import android.os.Bundle
@@ -228,20 +227,15 @@ class GameActivity : AppCompatActivity() {
                 val channels = (packed and 0xffff).toInt().coerceIn(1, 2)
                 val channelMask = if (channels == 2) AudioFormat.CHANNEL_OUT_STEREO else AudioFormat.CHANNEL_OUT_MONO
                 val minBuffer = AudioTrack.getMinBufferSize(rate, channelMask, AudioFormat.ENCODING_PCM_16BIT)
-                val bufferSize = maxOf(minBuffer.takeIf { it > 0 } ?: 0, rate * channels * 2 / 2, 4096)
-                track = AudioTrack.Builder()
-                    .setAudioAttributes(AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_GAME)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-                        .build())
-                    .setAudioFormat(AudioFormat.Builder()
-                        .setSampleRate(rate)
-                        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                        .setChannelMask(channelMask)
-                        .build())
-                    .setBufferSizeInBytes(bufferSize)
-                    .setTransferMode(AudioTrack.MODE_STREAM)
-                    .build()
+                val bufferSize = maxOf(if (minBuffer > 0) minBuffer else 0, rate * channels * 2 / 2, 4096)
+                track = AudioTrack(
+                    android.media.AudioManager.STREAM_MUSIC,
+                    rate,
+                    channelMask,
+                    AudioFormat.ENCODING_PCM_16BIT,
+                    bufferSize,
+                    AudioTrack.MODE_STREAM,
+                )
                 if (track?.state != AudioTrack.STATE_INITIALIZED) {
                     android.util.Log.e("PocketHLE", "AudioTrack was not initialized")
                     return@Thread
@@ -286,7 +280,7 @@ class GameActivity : AppCompatActivity() {
     private fun writeAudio(track: AudioTrack, pcm: ShortArray) {
         var offset = 0
         while (offset < pcm.size && audioRunning) {
-            val written = track.write(pcm, offset, pcm.size - offset, AudioTrack.WRITE_BLOCKING)
+            val written = track.write(pcm, offset, pcm.size - offset)
             if (written <= 0) return
             offset += written
         }

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameAdapter.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameAdapter.kt
@@ -59,7 +59,7 @@ class GameAdapter(
                 icon.imageTintList = null
             } else {
                 icon.setImageResource(R.drawable.ic_game)
-                icon.imageTintList = itemView.context.getColorStateList(com.google.android.material.R.color.material_dynamic_primary40)
+                icon.setColorFilter(itemView.context.resources.getColor(R.color.primary))
             }
             subtitle.text = entry.provider?.takeIf { it.isNotEmpty() }
                 ?: entry.sourceCab

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameAdapter.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameAdapter.kt
@@ -65,7 +65,8 @@ class GameAdapter(
                 ?: entry.sourceCab
             backendLabel.text = itemView.context.getString(
                 R.string.backend_label,
-                entry.settings.cpuBackend.replaceFirstChar { c -> c.uppercase() },
+                entry.settings.cpuBackend.substring(0, 1).toUpperCase(java.util.Locale.US) +
+                    entry.settings.cpuBackend.substring(1),
             )
             runBtn.setOnClickListener { onRun(entry) }
             settingsBtn.setOnClickListener { onSettings(entry) }

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/Library.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/Library.kt
@@ -29,7 +29,7 @@ object LibraryPaths {
     fun copyUriToCache(ctx: Context, uri: android.net.Uri, suggestedName: String): File {
         val cacheRoot = File(ctx.cacheDir, "imports").also { it.mkdirs() }
         val safe = suggestedName
-            .lowercase()
+            .toLowerCase(java.util.Locale.US)
             .replace(Regex("[^a-z0-9._-]"), "_")
             .ifEmpty { "import.cab" }
         val dest = File(cacheRoot, safe)

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/MainActivity.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/MainActivity.kt
@@ -8,7 +8,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.TextView
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
@@ -36,11 +35,6 @@ class MainActivity : AppCompatActivity() {
     private lateinit var emptyState: TextView
     private lateinit var rootDir: String
 
-    private val importGame = registerForActivityResult(
-        ActivityResultContracts.OpenDocument(),
-    ) { uri ->
-        if (uri != null) handleImport(uri)
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -66,13 +60,25 @@ class MainActivity : AppCompatActivity() {
         recycler.adapter = adapter
 
         findViewById<FloatingActionButton>(R.id.fab_import).setOnClickListener {
-            importGame.launch(arrayOf("application/vnd.ms-cab-compressed", "application/x-rar-compressed", "application/zip", "application/octet-stream", "*/*"))
+            val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = "*/*"
+            }
+            startActivityForResult(intent, REQUEST_IMPORT)
         }
     }
 
     override fun onResume() {
         super.onResume()
         refreshLibrary()
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: android.content.Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == REQUEST_IMPORT && resultCode == RESULT_OK) {
+            data?.data?.let { handleImport(it) }
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -163,7 +169,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun importArchiveOrExe(file: java.io.File): String {
-        return when (file.extension.lowercase()) {
+        return when (file.extension.toLowerCase(java.util.Locale.US)) {
             "exe" -> NativeBridge.importExe(rootDir, file.absolutePath)
             "rar" -> error("RAR is not supported on-device yet; extract it first and import the CAB or EXE")
             else -> NativeBridge.importCab(rootDir, file.absolutePath)
@@ -226,5 +232,9 @@ class MainActivity : AppCompatActivity() {
                 .putExtra(GameActivity.EXTRA_GAME_ID, entry.id)
                 .putExtra(GameActivity.EXTRA_GAME_NAME, entry.displayName),
         )
+    }
+
+    companion object {
+        private const val REQUEST_IMPORT = 4001
     }
 }

--- a/frontends/pocket-android/app/src/main/res/layout/activity_game.xml
+++ b/frontends/pocket-android/app/src/main/res/layout/activity_game.xml
@@ -40,7 +40,6 @@
             android:layout_gravity="top|start"
             android:layout_margin="8dp"
             android:background="#B0000000"
-            android:fontFamily="monospace"
             android:padding="6dp"
             android:text="FPS 0"
             android:textColor="#00FF00"
@@ -139,7 +138,7 @@
                     style="?android:attr/buttonStyleSmall"
                     android:layout_width="64dp"
                     android:layout_height="40dp"
-                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
                     android:text="@string/soft1_label" />
 
                 <Button
@@ -147,7 +146,7 @@
                     style="?android:attr/buttonStyleSmall"
                     android:layout_width="64dp"
                     android:layout_height="40dp"
-                    android:layout_marginStart="8dp"
+                    android:layout_marginLeft="8dp"
                     android:text="@string/soft2_label" />
             </LinearLayout>
 
@@ -180,7 +179,7 @@
                     style="?android:attr/buttonStyleSmall"
                     android:layout_width="48dp"
                     android:layout_height="40dp"
-                    android:layout_marginEnd="3dp"
+                    android:layout_marginRight="3dp"
                     android:text="@string/key_a_label" />
 
                 <Button
@@ -188,7 +187,8 @@
                     style="?android:attr/buttonStyleSmall"
                     android:layout_width="48dp"
                     android:layout_height="40dp"
-                    android:layout_marginHorizontal="3dp"
+                    android:layout_marginLeft="3dp"
+                    android:layout_marginRight="3dp"
                     android:text="@string/key_b_label" />
 
                 <Button
@@ -196,7 +196,7 @@
                     style="?android:attr/buttonStyleSmall"
                     android:layout_width="48dp"
                     android:layout_height="40dp"
-                    android:layout_marginStart="3dp"
+                    android:layout_marginLeft="3dp"
                     android:text="@string/key_c_label" />
             </LinearLayout>
         </LinearLayout>
@@ -207,7 +207,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorSurface"
-        android:fontFamily="monospace"
         android:maxLines="6"
         android:padding="8dp"
         android:scrollbars="vertical"

--- a/frontends/pocket-android/app/src/main/res/layout/item_game.xml
+++ b/frontends/pocket-android/app/src/main/res/layout/item_game.xml
@@ -28,7 +28,7 @@
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
+            android:layout_marginLeft="12dp"
             android:layout_weight="1"
             android:orientation="vertical">
 


### PR DESCRIPTION
## Что изменено

- Добавлена 32-битная сборка `armeabi-v7a` для HTC Desire C / Cortex-A5.
- Включён ARM Unicorn backend вместо trace-only stub.
- Android UI переведён на API-15 совместимые вызовы: старый Activity result flow, legacy AudioTrack, Java 8 bytecode.
- Сохранены OpenGL ES 2.0, pixel-perfect framebuffer scaling, touch/D-pad input и PCM audio.
- Убраны API-26+ атрибуты из manifest/layout.
- Добавлена сборочная конфигурация Android API 16 и отключён обязательный NEON для старых ARMv7 устройств.
- Обновлена документация на русском и английском.

## Проверки

- `cargo test --workspace --lib`
- `cargo test -p pocket-android-jni --features unicorn --lib`
- `git diff --check`

Сборку APK на этой машине выполнить нельзя: Android SDK/Gradle не установлены.
