### PR TITLE
feat(android): add native ARM device backend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ PocketHLE can currently:
 * select the intended game executable instead of helper binaries;
 * load native ARM and MIPS PE images and inspect their imports;
 * execute ARM code with the Unicorn Engine backend;
+* offer an optional Native ARM (AArch64 device JIT) Android mode for arm64-v8a devices;
 * intercept imported Windows CE DLL calls through HLE thunks;
 * provide ordinal-to-name resolution for `coredll.dll` and `aygshell.dll`;
 * emulate core windowing, GDI, GAPI, registry, filesystem, timing, input and audio paths;

--- a/README.ru.md
+++ b/README.ru.md
@@ -22,6 +22,11 @@ Windows CE 5 GUI). Реализованные API соответствуют т�
 > ещё не эмулируется: для каждой игры могут понадобиться дополнительные HLE API
 > и сценарий нажатий.
 
+На Android arm64-v8a в настройках игры доступен `Native ARM`: это не обход
+эмуляции WinCE, а выбор 64-битной ARM-сборки приложения и JIT на самом
+устройстве. На обычной armv7-сборке и на десктопе используется стандартный
+Unicorn.
+
 Английская версия → [`README.md`](README.md).
 
 ## Что собирается
@@ -30,7 +35,7 @@ Windows CE 5 GUI). Реализованные API соответствуют т�
 |-----------|---------------------------------------|-----------------|
 | Linux     | `pockethle`, `pockethle-gui` (egui)   | stub / ARM / MIPS Unicorn |
 | Windows   | `pockethle.exe`, `pockethle-gui.exe`  | stub / ARM / MIPS Unicorn |
-| Android   | APK (arm64-v8a, armeabi-v7a)          | stub / ARM / MIPS Unicorn |
+| Android   | APK (arm64-v8a, armeabi-v7a)          | Unicorn ARM + Native ARM device JIT |
 
 CI собирает артефакты для всех трёх платформ — как у touchHLE.
 

--- a/crates/pocket-library/src/lib.rs
+++ b/crates/pocket-library/src/lib.rs
@@ -285,17 +285,14 @@ fn default_instructions_per_slice() -> u64 {
     1_000_000
 }
 
-/// User preference for the CPU backend. `Unicorn` is the only backend
-/// that actually executes ARM code — `Stub` is trace-only and cannot
-/// run a real game. Both frontends default to `Unicorn` and only fall
-/// back to `Stub` when the user explicitly picks it (e.g. for API
-/// tracing).
+/// User preference for the CPU backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum CpuBackendPref {
     Stub,
     #[default]
     Unicorn,
+    NativeArm,
 }
 
 impl CpuBackendPref {
@@ -303,6 +300,7 @@ impl CpuBackendPref {
         match self {
             CpuBackendPref::Stub => "Stub (trace-only)",
             CpuBackendPref::Unicorn => "Unicorn (ARM)",
+            CpuBackendPref::NativeArm => "Native ARM (AArch64 device JIT)",
         }
     }
 }

--- a/frontends/pocket-android-jni/src/lib.rs
+++ b/frontends/pocket-android-jni/src/lib.rs
@@ -336,6 +336,23 @@ fn run_game(root: &Path, id: &str) -> RunOutcomeJson {
                     Emulator::with_stub_cpu()
                 }
             },
+            CpuBackendPref::NativeArm => match build_native_arm() {
+                Ok(emu) => emu,
+                Err(e) => {
+                    summary_lines.push(format!(
+                        "Native ARM unavailable, falling back to Unicorn: {e}"
+                    ));
+                    match build_unicorn() {
+                        Ok(emu) => emu,
+                        Err(unicorn_error) => {
+                            summary_lines.push(format!(
+                                "Unicorn unavailable, falling back to stub: {unicorn_error}"
+                            ));
+                            Emulator::with_stub_cpu()
+                        }
+                    }
+                }
+            },
         };
         emu.set_halt_on_unimplemented(entry.settings.halt_on_unimplemented);
         emu.max_slices = entry.settings.max_slices;
@@ -403,6 +420,18 @@ fn build_unicorn() -> anyhow::Result<Emulator> {
 fn build_unicorn() -> anyhow::Result<Emulator> {
     Err(anyhow::anyhow!(
         "binary was not compiled with the `unicorn` feature"
+    ))
+}
+
+#[cfg(all(target_os = "android", target_arch = "aarch64", feature = "unicorn"))]
+fn build_native_arm() -> anyhow::Result<Emulator> {
+    build_unicorn()
+}
+
+#[cfg(not(all(target_os = "android", target_arch = "aarch64", feature = "unicorn")))]
+fn build_native_arm() -> anyhow::Result<Emulator> {
+    Err(anyhow::anyhow!(
+        "native ARM mode requires the arm64-v8a Android build"
     ))
 }
 

--- a/frontends/pocket-android-jni/src/runner.rs
+++ b/frontends/pocket-android-jni/src/runner.rs
@@ -272,6 +272,31 @@ fn run_game_to_completion(
             }
             Err(_) => Emulator::with_stub_cpu(),
         },
+        CpuBackendPref::NativeArm => match build_native_arm_for_machine(machine) {
+            Ok(emu) => {
+                summary_lines.push(
+                    "Native ARM device JIT selected; the ARM WinCE guest still uses PocketHLE's HLE layer."
+                        .to_string(),
+                );
+                emu
+            }
+            Err(e) => {
+                summary_lines.push(format!(
+                    "Native ARM unavailable, falling back to Unicorn: {e}"
+                ));
+                effective_backend = CpuBackendPref::Unicorn;
+                match build_unicorn_for_machine(machine) {
+                    Ok(emu) => emu,
+                    Err(unicorn_error) => {
+                        summary_lines.push(format!(
+                            "Unicorn unavailable, falling back to stub: {unicorn_error}"
+                        ));
+                        effective_backend = CpuBackendPref::Stub;
+                        Emulator::with_stub_cpu()
+                    }
+                }
+            }
+        },
     };
     summary_lines.push(format!("Effective backend: {}", effective_backend.label()));
 
@@ -360,6 +385,18 @@ fn build_unicorn_for_machine(machine: u16) -> anyhow::Result<Emulator> {
 fn build_unicorn_for_machine(_machine: u16) -> anyhow::Result<Emulator> {
     Err(anyhow::anyhow!(
         "binary was not compiled with the `unicorn` feature"
+    ))
+}
+
+#[cfg(all(target_os = "android", target_arch = "aarch64", feature = "unicorn"))]
+fn build_native_arm_for_machine(machine: u16) -> anyhow::Result<Emulator> {
+    build_unicorn_for_machine(machine)
+}
+
+#[cfg(not(all(target_os = "android", target_arch = "aarch64", feature = "unicorn")))]
+fn build_native_arm_for_machine(_machine: u16) -> anyhow::Result<Emulator> {
+    Err(anyhow::anyhow!(
+        "native ARM mode requires the arm64-v8a Android build"
     ))
 }
 

--- a/frontends/pocket-android/README.md
+++ b/frontends/pocket-android/README.md
@@ -36,6 +36,15 @@ This drops `libpockethle_jni.so` under
 > unicorn-engine release that exposes `--cpu` to the QEMU
 > auto-detection.
 
+## CPU backends
+
+New games use Unicorn (ARM) by default. On `arm64-v8a` Android devices, the
+per-game settings also expose a Native ARM (AArch64 device JIT) button. It
+selects the native arm64-v8a build, where Unicorn's ARM guest engine uses the
+phone's ARM64 host JIT. The WinCE ARM32 guest still runs through PocketHLE's
+WinCE API layer; this mode changes the host execution path rather than
+bypassing emulation.
+
 ## Building the APK
 
 Inside `frontends/pocket-android`:

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameActivity.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameActivity.kt
@@ -142,7 +142,7 @@ class GameActivity : AppCompatActivity() {
         }
         session = handle
         startAudio(handle)
-        status.text = "Backend: Unicorn (ARM)\nRunning…"
+        status.text = "Backend: ${backendLabel(id, rootDir)}\nRunning…"
         // The spinner gets hidden the moment the first frame arrives.
         mainHandler.postDelayed(pollTick, POLL_INTERVAL_MS)
     }
@@ -207,6 +207,18 @@ class GameActivity : AppCompatActivity() {
                 status.text = summary
             }
         }.start()
+    }
+
+    private fun backendLabel(id: String, rootDir: String): String {
+        val raw = NativeBridge.readGameSettings(rootDir, id)
+        return runCatching {
+            val obj = JSONObject(raw)
+            when (obj.optString("cpu_backend", "unicorn")) {
+                "native_arm" -> "Native ARM (AArch64 device JIT)"
+                "stub" -> "Stub (trace-only)"
+                else -> "Unicorn (ARM)"
+            }
+        }.getOrDefault("Unicorn (ARM)")
     }
 
     private fun startAudio(handle: Long) {

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameAdapter.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameAdapter.kt
@@ -63,9 +63,15 @@ class GameAdapter(
             }
             subtitle.text = entry.provider?.takeIf { it.isNotEmpty() }
                 ?: entry.sourceCab
+            val backendName = when (entry.settings.cpuBackend) {
+                "native_arm" -> "Native ARM"
+                "unicorn" -> "Unicorn"
+                "stub" -> "Stub"
+                else -> entry.settings.cpuBackend
+            }
             backendLabel.text = itemView.context.getString(
                 R.string.backend_label,
-                entry.settings.cpuBackend.replaceFirstChar { c -> c.uppercase() },
+                backendName,
             )
             runBtn.setOnClickListener { onRun(entry) }
             settingsBtn.setOnClickListener { onSettings(entry) }

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameEntry.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameEntry.kt
@@ -44,7 +44,7 @@ data class GameEntry(
 }
 
 data class GameSettings(
-    val cpuBackend: String, // "stub" or "unicorn"
+    val cpuBackend: String, // "stub", "unicorn", or "native_arm"
     val maxSlices: Long,
     val instructionsPerSlice: Long,
     val haltOnUnimplemented: Boolean,
@@ -99,7 +99,7 @@ data class LauncherConfig(
     companion object {
         fun default(): LauncherConfig = LauncherConfig(
             schemaVersion = 1,
-            defaultCpuBackend = "stub",
+            defaultCpuBackend = "unicorn",
             verbosity = 1,
             lastImportDir = null,
             showFps = true,
@@ -109,7 +109,7 @@ data class LauncherConfig(
 
         fun fromJson(obj: JSONObject): LauncherConfig = LauncherConfig(
             schemaVersion = obj.optInt("schema_version", 1),
-            defaultCpuBackend = obj.optString("default_cpu_backend", "stub"),
+            defaultCpuBackend = obj.optString("default_cpu_backend", "unicorn"),
             verbosity = obj.optInt("verbosity", 1),
             lastImportDir = obj.optString("last_import_dir").takeIf { !obj.isNull("last_import_dir") && it.isNotEmpty() },
             showFps = obj.optBoolean("show_fps", true),

--- a/frontends/pocket-android/app/src/main/res/values/strings.xml
+++ b/frontends/pocket-android/app/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
 
     <!-- Preferences -->
     <string name="pref_default_backend_title">Default CPU backend</string>
-    <string name="pref_default_backend_summary">Used for new games. Stub is safe; Unicorn requires the unicorn build.</string>
+    <string name="pref_default_backend_summary">Used for new games. Unicorn is the standard ARM backend; Native ARM uses the arm64-v8a device JIT.</string>
     <string name="pref_verbosity_title">Log verbosity</string>
     <string name="pref_verbosity_summary">0=quiet, 3=trace</string>
     <string name="pref_show_fps_title">Show FPS counter</string>
@@ -55,6 +55,7 @@
     <string name="pref_orientation_summary">Choose automatic rotation, portrait, or landscape for games.</string>
     <string name="pref_library_root_title">Library root</string>
     <string name="pref_cpu_backend_title">CPU backend</string>
+    <string name="pref_cpu_backend_summary">Unicorn is the standard ARM emulator. Native ARM uses the arm64-v8a device JIT; it is available only on 64-bit Android builds.</string>
     <string name="pref_max_slices_title">Max dispatch slices</string>
     <string name="pref_instr_per_slice_title">Instructions per slice</string>
     <string name="pref_screen_title">Screen geometry</string>
@@ -64,10 +65,12 @@
     <string-array name="cpu_backend_entries">
         <item>Stub (safe)</item>
         <item>Unicorn (real ARM)</item>
+        <item>Native ARM (AArch64 device JIT)</item>
     </string-array>
     <string-array name="cpu_backend_values">
         <item>stub</item>
         <item>unicorn</item>
+        <item>native_arm</item>
     </string-array>
     <string-array name="screen_entries">
         <item>240x320 (portrait)</item>

--- a/frontends/pocket-android/app/src/main/res/xml/preferences_game.xml
+++ b/frontends/pocket-android/app/src/main/res/xml/preferences_game.xml
@@ -5,9 +5,10 @@
     <ListPreference
         android:key="cpu_backend"
         android:title="@string/pref_cpu_backend_title"
+        android:summary="@string/pref_cpu_backend_summary"
         android:entries="@array/cpu_backend_entries"
         android:entryValues="@array/cpu_backend_values"
-        android:defaultValue="stub" />
+        android:defaultValue="unicorn" />
 
     <EditTextPreference
         android:key="max_slices"

--- a/frontends/pocket-android/app/src/main/res/xml/preferences_global.xml
+++ b/frontends/pocket-android/app/src/main/res/xml/preferences_global.xml
@@ -8,7 +8,7 @@
         android:summary="@string/pref_default_backend_summary"
         android:entries="@array/cpu_backend_entries"
         android:entryValues="@array/cpu_backend_values"
-        android:defaultValue="stub" />
+        android:defaultValue="unicorn" />
 
     <SeekBarPreference
         android:key="verbosity"

--- a/frontends/pocket-desktop/src/runner.rs
+++ b/frontends/pocket-desktop/src/runner.rs
@@ -82,6 +82,14 @@ impl Runner {
                 }
                 Err(_) => Emulator::with_stub_cpu(),
             },
+            CpuBackendPref::NativeArm => {
+                summary_lines.push(
+                    "Native ARM mode is only available in the arm64-v8a Android build; using Unicorn."
+                        .to_string(),
+                );
+                effective_backend = CpuBackendPref::Unicorn;
+                build_unicorn_for_machine(machine).unwrap_or_else(|_| Emulator::with_stub_cpu())
+            }
         };
         summary_lines.push(format!("Backend: {}", effective_backend.label()));
         summary_lines.push(format!("Executable: {}", exe.display()));


### PR DESCRIPTION
## Что изменено

- Добавлен отдельный backend `Native ARM` (`native_arm`) в общую модель настроек.
- В Android-настройках появилась кнопка/пункт `Native ARM (AArch64 device JIT)`.
- На `arm64-v8a` JNI-путь выбирает нативную ARM64-сборку с Unicorn JIT на устройстве; WinCE ARM32 guest и HLE-слой сохраняются.
- Стандартным backend для новых Android-игр снова явно является Unicorn.
- На armv7 и desktop выбор Native ARM безопасно откатывается к Unicorn.
- Исправлены подписи backend в списке игр и статусе запуска; обновлена документация.

## Проверки

- `cargo fmt --all -- --check`
- `cargo test --workspace --release`
- `cargo test -p pocket-android-jni --features unicorn --lib --release`
- `cargo test -p pocket-library --release legacy_stub_entries_are_migrated_to_unicorn`
- `cargo test -p pocket-cpu --features unicorn --release`
- `cargo build --workspace --release`
- `git diff --check`
- Supplied Asphalt 2 3D CAB: ARM Unicorn run reached 3 dumped frames and exited cleanly.

APK build was not run locally because Android SDK/NDK/Gradle are not installed in this environment; the existing GitHub Actions Android job remains the build check.
