### PR TITLE
Fix Avalanche Snowboarding Windows Mobile startup loop

### DIFF
--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -90,6 +90,7 @@ pub fn register(d: &mut WinCeDispatcher) {
     // ---- Process / module / library ----
     d.register_handler(dll, "GetTickCount", get_tick_count);
     d.register_handler(dll, "Sleep", sleep);
+    d.register_handler(dll, "SuspendThread", suspend_thread);
     d.register_handler(dll, "ResumeThread", resume_thread);
     d.register_handler(dll, "ExitProcess", exit_process);
     d.register_handler(dll, "TerminateProcess", exit_process);
@@ -994,6 +995,7 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "log10", m_log10);
     d.register_handler(dll, "sqrt", m_sqrt);
     d.register_handler(dll, "floor", m_floor);
+    d.register_handler(dll, "floorf", m_floorf);
     d.register_handler(dll, "ceil", m_ceil);
     d.register_handler(dll, "fabs", m_fabs);
     d.register_handler(dll, "atan2", m_atan2);
@@ -1739,6 +1741,35 @@ fn sleep(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
         return Ok(outcome);
     }
     Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+/// `SuspendThread(HANDLE)` is used by Avalanche's cooperative worker
+/// control loop to pause a helper before it changes display state.
+///
+/// PocketHLE already serializes guest threads at API boundaries, so the
+/// operation is represented by marking the synthetic thread as not ready;
+/// the current worker yields immediately and the main thread continues.
+fn suspend_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    if handle == FAKE_CURRENT_THREAD_HANDLE {
+        if let Some(outcome) = park_worker(ctx, 0)? {
+            return Ok(outcome);
+        }
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    if let Some(index) = ctx
+        .kernel
+        .threads
+        .iter()
+        .position(|thread| thread.handle == handle && !thread.finished)
+    {
+        ctx.kernel.threads[index].started = false;
+        if let Some(outcome) = park_worker(ctx, 0)? {
+            return Ok(outcome);
+        }
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    Ok(DispatchOutcome::ReturnedR0(0xffff_ffff))
 }
 
 fn resume_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -10558,6 +10589,10 @@ fn m_sqrt(c: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
 }
 fn m_floor(c: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     libm_unary_d(c, f64::floor)
+}
+
+fn m_floorf(c: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(ret_f32(read_f32(c, 0)?.floor()))
 }
 fn m_ceil(c: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     libm_unary_d(c, f64::ceil)


### PR DESCRIPTION
## What changed

- Implemented `coredll.dll!SuspendThread` for the cooperative Windows Mobile worker loop used by Avalanche Snowboarding.
- Added the missing single-precision `coredll.dll!floorf` implementation.
- The thread handler preserves the existing PocketHLE cooperative scheduler: the current synthetic thread yields, and the main thread continues instead of falling through the unimplemented-call path.

## Diagnosis

The supplied ARM Thumb CAB loads successfully and reaches the GDI display setup (`CreateDIBSection` for a 480x640 surface), but the runtime then repeatedly calls `SuspendThread` on the fake current-thread handle. Before this change, every call was unimplemented and returned zero. The trace showed the loop cycling through `PeekMessageW` / `Sleep` / `ChangeDisplaySettingsEx` / `SuspendThread`, with no subsequent gameplay rendering and `frame_counter=2` (the initial GDI setup only). `floorf` was also imported and previously unimplemented.

The implementation follows the existing PocketHLE cooperative-thread model and the Windows Mobile message-pump behavior documented in the project guidance: an empty worker queue must yield rather than terminate or claim a frame. The historical Microsoft Windows Mobile documentation was consulted for the native platform/API context, and GitHub search was used to compare the standard message-pump/frame-loop pattern.

## Testing

- `cargo build --release -p pocket-cli --features unicorn` — passed.
- `cargo fmt --all -- --check` — passed.
- `cargo test --workspace` — passed: all workspace tests passed.
- `tools/ai-tap-sequence.py` was run against the supplied CAB on the Unicorn ARM backend with three taps and unlimited synthetic message budget. The run exited cleanly with `RC=0`, registered 2642 API stubs, and produced a final framebuffer snapshot with `frame_counter=2`.
- A 500,000-slice API trace confirmed that the previous unimplemented `SuspendThread` failures are gone; the remaining loop still does not reach the game's render path. It repeatedly cycles through `Sleep`, `PeekMessageW`, `ChangeDisplaySettingsEx`, `SuspendThread`, and `ReadMsgQueue` and ends at the slice limit with `frame_counter=2`.

## Evidence

The run output is included in the conversation/workspace under `proof/avalanche-snowboarding/` when available. No screenshot is attached because the captured framebuffer remained completely black; claiming gameplay or a successful visual proof would be inaccurate. This PR is intentionally limited to the verified missing APIs and does not claim the readiness criteria are met.
