### PR TITLE
fix: emulate Gizmondo SD card volume

### DIFF
--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -69,6 +69,7 @@ const FAKE_MODAL_HWND: u32 = 0xDEAD_0003;
 /// hence a handle distinct from [`FAKE_HWND`].
 pub const FAKE_STATUSBAR_HWND: u32 = 0xDEAD_0C01;
 const INVALID_HANDLE_VALUE: u32 = 0xFFFF_FFFF;
+const SD_VOLUME_HANDLE: u32 = 0xDEAD_F200;
 
 /// Every window handle we ever hand the guest. Handlers that answer
 /// questions *about* a window (`IsWindow`, `IsWindowVisible`, ...) have
@@ -259,6 +260,7 @@ pub fn register(d: &mut WinCeDispatcher) {
 
     // ---- File I/O backed by the VFS ----
     d.register_handler(dll, "CreateFileW", create_file_w);
+    d.register_handler(dll, "DeviceIoControl", device_io_control);
     d.register_handler(dll, "ReadFile", read_file);
     d.register_handler(dll, "WriteFile", write_file);
     d.register_handler(dll, "FlushFileBuffers", flush_file_buffers);
@@ -4465,6 +4467,14 @@ fn create_file_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
         Err(_) => return Ok(DispatchOutcome::ReturnedR0(INVALID_HANDLE_VALUE)),
     };
     let path = String::from_utf16_lossy(&name_w);
+    if path.eq_ignore_ascii_case("\\SD Card\\Vol:")
+        || path.eq_ignore_ascii_case("\\Storage Card\\Vol:")
+    {
+        log::debug!(
+            "CreateFileW({path:?}) -> synthetic Gizmondo SD volume 0x{SD_VOLUME_HANDLE:08x}"
+        );
+        return Ok(DispatchOutcome::ReturnedR0(SD_VOLUME_HANDLE));
+    }
     let access = match (
         access_flags & 0x8000_0000 != 0,
         access_flags & 0x4000_0000 != 0,
@@ -4492,6 +4502,30 @@ fn create_file_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
             Ok(DispatchOutcome::ReturnedR0(INVALID_HANDLE_VALUE))
         }
     }
+}
+
+fn device_io_control(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let code = ctx.arg_u32(1)?;
+    let _in_buffer = ctx.arg_u32(2)?;
+    let _in_size = ctx.arg_u32(3)?;
+    let out_buffer = ctx.arg_u32(4)?;
+    let out_size = ctx.arg_u32(5)?;
+    let bytes_returned = ctx.arg_u32(6)?;
+    let valid_volume = handle == SD_VOLUME_HANDLE;
+    if valid_volume && out_buffer != 0 && out_size != 0 {
+        ctx.cpu
+            .write_mem(out_buffer, &vec![0u8; out_size.min(256) as usize])?;
+    }
+    if valid_volume && bytes_returned != 0 {
+        ctx.cpu
+            .write_mem(bytes_returned, &out_size.min(256).to_le_bytes())?;
+    }
+    log::debug!(
+        "DeviceIoControl(handle=0x{handle:08x}, code=0x{code:08x}, out_size={out_size}) -> {}",
+        u32::from(valid_volume)
+    );
+    Ok(DispatchOutcome::ReturnedR0(u32::from(valid_volume)))
 }
 
 /// `BOOL ReadFile(HANDLE h, void* buf, DWORD count, DWORD* read,
@@ -4542,6 +4576,9 @@ fn flush_file_buffers(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
 fn close_handle(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let handle = ctx.arg_u32(0)?;
     let _ = ctx.kernel.vfs.close(handle);
+    if handle == SD_VOLUME_HANDLE {
+        log::debug!("CloseHandle(synthetic Gizmondo SD volume)");
+    }
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 

--- a/frontends/pocket-cli/src/archive.rs
+++ b/frontends/pocket-cli/src/archive.rs
@@ -844,7 +844,13 @@ fn prepare_zip(path: &Path) -> Result<Launcher> {
     )];
     let guest_exe_path = if gizmondo_layout {
         extra_mounts.push(("\\SD Card\\".to_string(), tmp.path().to_path_buf()));
-        Some("\\SD Card\\Alien Hominid.exe".to_string())
+        extra_mounts.push(("\\Storage Card\\".to_string(), tmp.path().to_path_buf()));
+        let relative = exe_path
+            .strip_prefix(tmp.path())
+            .unwrap_or(&exe_path)
+            .to_string_lossy()
+            .replace('/', "\\");
+        Some(format!("\\SD Card\\{relative}"))
     } else {
         None
     };
@@ -865,12 +871,24 @@ fn is_gizmondo_layout(written: &[PathBuf], exe_path: &Path) -> bool {
         .file_name()
         .map(|name| name.to_string_lossy().to_ascii_lowercase())
         .unwrap_or_default();
-    exe_name == "alien hominid.exe"
+    let alien_hominid = exe_name == "alien hominid.exe"
         && written.iter().any(|entry| {
             entry
                 .file_name()
                 .is_some_and(|name| name.eq_ignore_ascii_case("Sky.bmp"))
-        })
+        });
+    let nested_gizmondo = exe_path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_string_lossy()
+            .to_ascii_lowercase()
+            .starts_with("gzga")
+    }) && written.iter().any(|entry| {
+        entry
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("cfl"))
+    });
+    alien_hominid || nested_gizmondo
 }
 
 /// Keep `inner` on disk for the rest of the process's lifetime and
@@ -1038,6 +1056,19 @@ mod tests {
         assert!(!is_gizmondo_layout(
             &[PathBuf::from("/tmp/pockethle/Alien Hominid.exe")],
             Path::new("/tmp/pockethle/Alien Hominid.exe")
+        ));
+    }
+
+    #[test]
+    fn gizmondo_layout_uses_the_real_nested_module_path() {
+        let entries = vec![
+            PathBuf::from("/tmp/pockethle/gzga200010/sce/SCE-gizmondo.cfl"),
+            PathBuf::from("/tmp/pockethle/gzga200010/sce/sce.exe"),
+            PathBuf::from("/tmp/pockethle/gzga200010/sce/sce-gizmondo-loading.tga"),
+        ];
+        assert!(is_gizmondo_layout(
+            &entries,
+            Path::new("/tmp/pockethle/gzga200010/sce/sce.exe")
         ));
     }
 }


### PR DESCRIPTION
## Что исправлено

- эмулируется `\SD Card\Vol:` и `\Storage Card\Vol:` для игр Gizmondo;
- добавлен успешный `DeviceIoControl` для synthetic SD volume;
- ZIP-архивы с вложенной структурой Gizmondo (`gzga.../*.cfl`) монтируются с реальным путём модуля, а не только как Alien Hominid;
- добавлены regression-тесты для вложенной структуры.

Проверено: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`.

Тестовый архив: Fathammer Classics Gizmondo.