### PR TITLE
feat(gizmondo): emulate SDK DirectDraw surfaces

### DIFF
--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -682,6 +682,16 @@ pub struct LoadedModule {
     pub refcount: u32,
 }
 
+/// Host-side bookkeeping for one DirectDraw surface.
+#[derive(Debug, Clone, Copy)]
+pub struct DdrawSurface {
+    pub buffer: u32,
+    pub width: u32,
+    pub height: u32,
+    pub pitch: u32,
+    pub primary: bool,
+}
+
 /// Mutable kernel state that persists across calls and that handlers
 /// need to read or modify. Bundled into one struct so we can hand it
 /// out by `&mut` without conflicting with the immutable parts of
@@ -725,6 +735,10 @@ pub struct KernelState {
     /// (a bare-exe run) or the CAB extraction root, which is where a
     /// game's satellite DLLs sit next to it on a real device.
     pub module_search_dirs: Vec<PathBuf>,
+    /// Host-side DirectDraw surfaces keyed by their guest interface pointer.
+    pub ddraw_surfaces: HashMap<u32, DdrawSurface>,
+    /// Surface interface pointer used by the primary display surface.
+    pub ddraw_primary_surface: Option<u32>,
     /// Set the first time `GXBeginDraw` runs. The dispatcher maps the
     /// framebuffer region into the guest VA space lazily — but that
     /// requires `&mut dyn Cpu`, which isn't available outside a call,
@@ -1897,6 +1911,8 @@ impl Process {
                 modules: Vec::new(),
                 next_module_base: MODULE_REGION_BASE,
                 module_search_dirs,
+                ddraw_surfaces: HashMap::new(),
+                ddraw_primary_surface: None,
                 fb_mapped: false,
                 gx_readback_scratch: Vec::new(),
                 mem_op_scratch: Vec::new(),

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -13271,6 +13271,8 @@ mod tests {
             modules: Vec::new(),
             next_module_base: pocket_kernel::MODULE_REGION_BASE,
             module_search_dirs: Vec::new(),
+            ddraw_surfaces: std::collections::HashMap::new(),
+            ddraw_primary_surface: None,
             fb_mapped: false,
             gx_readback_scratch: Vec::new(),
             mem_op_scratch: Vec::new(),

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -69,6 +69,7 @@ const FAKE_MODAL_HWND: u32 = 0xDEAD_0003;
 /// hence a handle distinct from [`FAKE_HWND`].
 pub const FAKE_STATUSBAR_HWND: u32 = 0xDEAD_0C01;
 const INVALID_HANDLE_VALUE: u32 = 0xFFFF_FFFF;
+const SD_VOLUME_HANDLE: u32 = 0xDEAD_F200;
 
 /// Every window handle we ever hand the guest. Handlers that answer
 /// questions *about* a window (`IsWindow`, `IsWindowVisible`, ...) have
@@ -259,6 +260,7 @@ pub fn register(d: &mut WinCeDispatcher) {
 
     // ---- File I/O backed by the VFS ----
     d.register_handler(dll, "CreateFileW", create_file_w);
+    d.register_handler(dll, "DeviceIoControl", device_io_control);
     d.register_handler(dll, "ReadFile", read_file);
     d.register_handler(dll, "WriteFile", write_file);
     d.register_handler(dll, "FlushFileBuffers", flush_file_buffers);
@@ -4465,6 +4467,14 @@ fn create_file_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
         Err(_) => return Ok(DispatchOutcome::ReturnedR0(INVALID_HANDLE_VALUE)),
     };
     let path = String::from_utf16_lossy(&name_w);
+    if path.eq_ignore_ascii_case("\\SD Card\\Vol:")
+        || path.eq_ignore_ascii_case("\\Storage Card\\Vol:")
+    {
+        log::debug!(
+            "CreateFileW({path:?}) -> synthetic Gizmondo SD volume 0x{SD_VOLUME_HANDLE:08x}"
+        );
+        return Ok(DispatchOutcome::ReturnedR0(SD_VOLUME_HANDLE));
+    }
     let access = match (
         access_flags & 0x8000_0000 != 0,
         access_flags & 0x4000_0000 != 0,
@@ -4492,6 +4502,30 @@ fn create_file_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
             Ok(DispatchOutcome::ReturnedR0(INVALID_HANDLE_VALUE))
         }
     }
+}
+
+fn device_io_control(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let code = ctx.arg_u32(1)?;
+    let _in_buffer = ctx.arg_u32(2)?;
+    let _in_size = ctx.arg_u32(3)?;
+    let out_buffer = ctx.arg_u32(4)?;
+    let out_size = ctx.arg_u32(5)?;
+    let bytes_returned = ctx.arg_u32(6)?;
+    let valid_volume = handle == SD_VOLUME_HANDLE;
+    if valid_volume && out_buffer != 0 && out_size != 0 {
+        ctx.cpu
+            .write_mem(out_buffer, &vec![0u8; out_size.min(256) as usize])?;
+    }
+    if valid_volume && bytes_returned != 0 {
+        ctx.cpu
+            .write_mem(bytes_returned, &out_size.min(256).to_le_bytes())?;
+    }
+    log::debug!(
+        "DeviceIoControl(handle=0x{handle:08x}, code=0x{code:08x}, out_size={out_size}) -> {}",
+        u32::from(valid_volume)
+    );
+    Ok(DispatchOutcome::ReturnedR0(u32::from(valid_volume)))
 }
 
 /// `BOOL ReadFile(HANDLE h, void* buf, DWORD count, DWORD* read,
@@ -4542,6 +4576,9 @@ fn flush_file_buffers(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
 fn close_handle(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let handle = ctx.arg_u32(0)?;
     let _ = ctx.kernel.vfs.close(handle);
+    if handle == SD_VOLUME_HANDLE {
+        log::debug!("CloseHandle(synthetic Gizmondo SD volume)");
+    }
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 

--- a/crates/pocket-winceapi/src/ddraw.rs
+++ b/crates/pocket-winceapi/src/ddraw.rs
@@ -1,11 +1,13 @@
 use pocket_cpu::Prot;
-use pocket_kernel::{DispatchOutcome, KernelError, SYNTHETIC_FRAMEBUFFER_BASE};
+use pocket_kernel::{DdrawSurface, DispatchOutcome, KernelError, SYNTHETIC_FRAMEBUFFER_BASE};
 
 use crate::{CallCtx, WinCeDispatcher};
 
 const FAKE_DDRAW: u32 = 0xDEAD_DD01;
 const FAKE_SURFACE: u32 = 0xDEAD_DD02;
 const FAKE_PALETTE: u32 = 0xDEAD_DD03;
+const DDRAW_PRIMARY_SURFACE: u32 = 0xDEAD_DD05;
+const DDRAW_BACK_SURFACE: u32 = 0xDEAD_DD06;
 const FAKE_MODULE_HANDLE: u32 = 0x1000_0003;
 
 const DDRAW_METHODS: [&str; 22] = [
@@ -141,6 +143,8 @@ pub fn register(d: &mut WinCeDispatcher) {
             "surface_add_ref" => add_ref,
             "surface_release" => release,
             "surface_get_attached" => surface_get_attached,
+            "surface_blt" | "surface_blt_batch" | "surface_blt_fast" => surface_blt,
+            "surface_flip" => surface_flip,
             "surface_get_blt_status" | "surface_get_flip_status" => surface_status,
             "surface_get_caps" | "surface_get_pixel_format" => surface_ok,
             "surface_get_color_key" => surface_get_color_key,
@@ -248,8 +252,66 @@ fn ddraw_initialize(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
 }
 
 fn ddraw_create_surface(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let desc = ctx.arg_u32(1)?;
     let out = ctx.arg_u32(2)?;
-    let object = alloc_object(ctx, &SURFACE_METHODS, FAKE_SURFACE)?;
+    let flags = if desc != 0 {
+        ctx.cpu.read_u32_le(desc + 4)?
+    } else {
+        0
+    };
+    let caps = if desc != 0 {
+        ctx.cpu.read_u32_le(desc + 108)?
+    } else {
+        0
+    };
+    let primary = caps & 0x0000_0200 != 0;
+    let width = if desc != 0 && flags & 0x0000_0004 != 0 {
+        ctx.cpu.read_u32_le(desc + 16)?.max(1)
+    } else {
+        ctx.kernel.framebuffer.width
+    };
+    let height = if desc != 0 && flags & 0x0000_0002 != 0 {
+        ctx.cpu.read_u32_le(desc + 12)?.max(1)
+    } else {
+        ctx.kernel.framebuffer.height
+    };
+    let object = alloc_object(
+        ctx,
+        &SURFACE_METHODS,
+        if primary {
+            DDRAW_PRIMARY_SURFACE
+        } else {
+            DDRAW_BACK_SURFACE
+        },
+    )?;
+    if object != 0 {
+        let buffer = if primary {
+            ensure_framebuffer(ctx)?;
+            SYNTHETIC_FRAMEBUFFER_BASE
+        } else {
+            let pitch = width.saturating_mul(2);
+            let size = pitch.saturating_mul(height);
+            let buffer = ctx.kernel.heap.alloc(size).unwrap_or(0);
+            if buffer != 0 {
+                ctx.cpu.write_mem(buffer, &vec![0; size as usize])?;
+            }
+            buffer
+        };
+        let pitch = width.saturating_mul(2);
+        ctx.kernel.ddraw_surfaces.insert(
+            object,
+            DdrawSurface {
+                buffer,
+                width,
+                height,
+                pitch,
+                primary,
+            },
+        );
+        if primary {
+            ctx.kernel.ddraw_primary_surface = Some(object);
+        }
+    }
     if out != 0 {
         ctx.cpu.write_mem(out, &object.to_le_bytes())?;
     }
@@ -310,7 +372,14 @@ fn ddraw_enum_display_modes(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, K
 fn ddraw_get_display_mode(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let desc = ctx.arg_u32(1)?;
     if desc != 0 && !(0x5000_0000..0x5f00_0000).contains(&desc) {
-        write_surface_desc(ctx, desc, SYNTHETIC_FRAMEBUFFER_BASE)?;
+        let surface = DdrawSurface {
+            buffer: SYNTHETIC_FRAMEBUFFER_BASE,
+            width: ctx.kernel.framebuffer.width,
+            height: ctx.kernel.framebuffer.height,
+            pitch: ctx.kernel.framebuffer.stride_bytes(),
+            primary: true,
+        };
+        write_surface_desc(ctx, desc, &surface)?;
     }
     Ok(DispatchOutcome::ReturnedR0(0))
 }
@@ -352,17 +421,21 @@ fn surface_status(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError
     Ok(DispatchOutcome::ReturnedR0(0))
 }
 
-fn write_surface_desc(ctx: &mut CallCtx<'_>, desc: u32, surface: u32) -> Result<(), KernelError> {
+fn write_surface_desc(
+    ctx: &mut CallCtx<'_>,
+    desc: u32,
+    surface: &DdrawSurface,
+) -> Result<(), KernelError> {
     if desc == 0 {
         return Ok(());
     }
     let mut bytes = [0u8; 124];
     bytes[0..4].copy_from_slice(&124u32.to_le_bytes());
     bytes[4..8].copy_from_slice(&0x0000_100fu32.to_le_bytes());
-    bytes[8..12].copy_from_slice(&ctx.kernel.framebuffer.height.to_le_bytes());
-    bytes[12..16].copy_from_slice(&ctx.kernel.framebuffer.width.to_le_bytes());
-    bytes[16..20].copy_from_slice(&ctx.kernel.framebuffer.stride_bytes().to_le_bytes());
-    bytes[36..40].copy_from_slice(&surface.to_le_bytes());
+    bytes[8..12].copy_from_slice(&surface.height.to_le_bytes());
+    bytes[12..16].copy_from_slice(&surface.width.to_le_bytes());
+    bytes[16..20].copy_from_slice(&surface.pitch.to_le_bytes());
+    bytes[36..40].copy_from_slice(&surface.buffer.to_le_bytes());
     bytes[56..60].copy_from_slice(&32u32.to_le_bytes());
     bytes[60..64].copy_from_slice(&0x40u32.to_le_bytes());
     bytes[68..72].copy_from_slice(&16u32.to_le_bytes());
@@ -371,6 +444,118 @@ fn write_surface_desc(ctx: &mut CallCtx<'_>, desc: u32, surface: u32) -> Result<
     bytes[80..84].copy_from_slice(&0x001fu32.to_le_bytes());
     ctx.cpu.write_mem(desc, &bytes)?;
     Ok(())
+}
+
+fn surface_state(ctx: &CallCtx<'_>, object: u32) -> DdrawSurface {
+    ctx.kernel
+        .ddraw_surfaces
+        .get(&object)
+        .copied()
+        .unwrap_or(DdrawSurface {
+            buffer: SYNTHETIC_FRAMEBUFFER_BASE,
+            width: ctx.kernel.framebuffer.width,
+            height: ctx.kernel.framebuffer.height,
+            pitch: ctx.kernel.framebuffer.stride_bytes(),
+            primary: true,
+        })
+}
+
+fn parse_rect(
+    ctx: &mut CallCtx<'_>,
+    rect: u32,
+    width: u32,
+    height: u32,
+) -> Result<(u32, u32, u32, u32), KernelError> {
+    if rect == 0 {
+        return Ok((0, 0, width, height));
+    }
+    let left = ctx.cpu.read_u32_le(rect)? as i32;
+    let top = ctx.cpu.read_u32_le(rect + 4)? as i32;
+    let right = ctx.cpu.read_u32_le(rect + 8)? as i32;
+    let bottom = ctx.cpu.read_u32_le(rect + 12)? as i32;
+    Ok((
+        left.max(0) as u32,
+        top.max(0) as u32,
+        right.max(left).min(width as i32) as u32,
+        bottom.max(top).min(height as i32) as u32,
+    ))
+}
+
+fn surface_blt(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let dst_object = ctx.arg_u32(0)?;
+    let dst = surface_state(ctx, dst_object);
+    let (dx, dy, dw, dh, src_object, src_rect) =
+        if ctx.thunk.friendly_name.as_deref() == Some("surface_blt_fast") {
+            let x = ctx.arg_u32(1)?;
+            let y = ctx.arg_u32(2)?;
+            let src_object = ctx.arg_u32(3)?;
+            let src = surface_state(ctx, src_object);
+            let rect_ptr = ctx.arg_u32(4)?;
+            let rect = parse_rect(ctx, rect_ptr, src.width, src.height)?;
+            (x, y, rect.2 - rect.0, rect.3 - rect.1, src_object, rect)
+        } else {
+            let dst_rect_ptr = ctx.arg_u32(1)?;
+            let dst_rect = parse_rect(ctx, dst_rect_ptr, dst.width, dst.height)?;
+            let src_object = ctx.arg_u32(2)?;
+            let src = surface_state(ctx, src_object);
+            let src_rect_ptr = ctx.arg_u32(3)?;
+            let src_rect = parse_rect(ctx, src_rect_ptr, src.width, src.height)?;
+            (
+                dst_rect.0,
+                dst_rect.1,
+                dst_rect.2 - dst_rect.0,
+                dst_rect.3 - dst_rect.1,
+                src_object,
+                src_rect,
+            )
+        };
+    let src = surface_state(ctx, src_object);
+    let width = dw
+        .min(src_rect.2.saturating_sub(src_rect.0))
+        .min(dst.width.saturating_sub(dx));
+    let height = dh
+        .min(src_rect.3.saturating_sub(src_rect.1))
+        .min(dst.height.saturating_sub(dy));
+    if width == 0 || height == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let row_bytes = width.saturating_mul(2) as usize;
+    let mut pixels = vec![0u8; row_bytes * height as usize];
+    for row in 0..height {
+        let src_va = src.buffer
+            + (src_rect.1 + row).saturating_mul(src.pitch)
+            + src_rect.0.saturating_mul(2);
+        ctx.cpu.read_mem_into(
+            src_va,
+            &mut pixels[row as usize * row_bytes..(row as usize + 1) * row_bytes],
+        )?;
+    }
+    for row in 0..height {
+        let dst_va = dst.buffer + (dy + row).saturating_mul(dst.pitch) + dx.saturating_mul(2);
+        ctx.cpu.write_mem(
+            dst_va,
+            &pixels[row as usize * row_bytes..(row as usize + 1) * row_bytes],
+        )?;
+    }
+    if dst.primary {
+        let size = ctx.kernel.framebuffer.byte_size();
+        let pixels = ctx.cpu.read_mem(SYNTHETIC_FRAMEBUFFER_BASE, size)?;
+        ctx.kernel.framebuffer.pixels.copy_from_slice(&pixels);
+        ctx.kernel.framebuffer.mark_dirty();
+    }
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn surface_flip(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let object = ctx.arg_u32(0)?;
+    let primary = surface_state(ctx, object);
+    if primary.primary {
+        let size = ctx.kernel.framebuffer.byte_size();
+        let pixels = ctx.cpu.read_mem(primary.buffer, size)?;
+        ctx.kernel.framebuffer.pixels.copy_from_slice(&pixels);
+        ctx.kernel.framebuffer.mark_dirty();
+    }
+    Ok(DispatchOutcome::ReturnedR0(0))
 }
 
 fn surface_get_color_key(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -382,9 +567,11 @@ fn surface_get_color_key(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kerne
 }
 
 fn surface_desc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let object = ctx.arg_u32(0)?;
     let desc = ctx.arg_u32(1)?;
     if desc != 0 && !(0x5000_0000..0x5f00_0000).contains(&desc) {
-        write_surface_desc(ctx, desc, SYNTHETIC_FRAMEBUFFER_BASE)?;
+        let surface = surface_state(ctx, object);
+        write_surface_desc(ctx, desc, &surface)?;
     }
     Ok(DispatchOutcome::ReturnedR0(0))
 }
@@ -422,10 +609,11 @@ fn surface_is_lost(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
 }
 
 fn surface_lock(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
-    ensure_framebuffer(ctx)?;
+    let object = ctx.arg_u32(0)?;
     let desc = ctx.arg_u32(2)?;
+    let surface = surface_state(ctx, object);
     if desc != 0 {
-        write_surface_desc(ctx, desc, SYNTHETIC_FRAMEBUFFER_BASE)?;
+        write_surface_desc(ctx, desc, &surface)?;
     }
     Ok(DispatchOutcome::ReturnedR0(0))
 }

--- a/crates/pocket-winceapi/src/gx.rs
+++ b/crates/pocket-winceapi/src/gx.rs
@@ -296,6 +296,8 @@ pub(crate) mod tests {
             modules: Vec::new(),
             next_module_base: pocket_kernel::MODULE_REGION_BASE,
             module_search_dirs: Vec::new(),
+            ddraw_surfaces: std::collections::HashMap::new(),
+            ddraw_primary_surface: None,
             fb_mapped: false,
             gx_readback_scratch: Vec::new(),
             mem_op_scratch: Vec::new(),

--- a/frontends/pocket-cli/src/archive.rs
+++ b/frontends/pocket-cli/src/archive.rs
@@ -844,7 +844,13 @@ fn prepare_zip(path: &Path) -> Result<Launcher> {
     )];
     let guest_exe_path = if gizmondo_layout {
         extra_mounts.push(("\\SD Card\\".to_string(), tmp.path().to_path_buf()));
-        Some("\\SD Card\\Alien Hominid.exe".to_string())
+        extra_mounts.push(("\\Storage Card\\".to_string(), tmp.path().to_path_buf()));
+        let relative = exe_path
+            .strip_prefix(tmp.path())
+            .unwrap_or(&exe_path)
+            .to_string_lossy()
+            .replace('/', "\\");
+        Some(format!("\\SD Card\\{relative}"))
     } else {
         None
     };
@@ -865,12 +871,24 @@ fn is_gizmondo_layout(written: &[PathBuf], exe_path: &Path) -> bool {
         .file_name()
         .map(|name| name.to_string_lossy().to_ascii_lowercase())
         .unwrap_or_default();
-    exe_name == "alien hominid.exe"
+    let alien_hominid = exe_name == "alien hominid.exe"
         && written.iter().any(|entry| {
             entry
                 .file_name()
                 .is_some_and(|name| name.eq_ignore_ascii_case("Sky.bmp"))
-        })
+        });
+    let nested_gizmondo = exe_path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_string_lossy()
+            .to_ascii_lowercase()
+            .starts_with("gzga")
+    }) && written.iter().any(|entry| {
+        entry
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("cfl"))
+    });
+    alien_hominid || nested_gizmondo
 }
 
 /// Keep `inner` on disk for the rest of the process's lifetime and
@@ -1038,6 +1056,19 @@ mod tests {
         assert!(!is_gizmondo_layout(
             &[PathBuf::from("/tmp/pockethle/Alien Hominid.exe")],
             Path::new("/tmp/pockethle/Alien Hominid.exe")
+        ));
+    }
+
+    #[test]
+    fn gizmondo_layout_uses_the_real_nested_module_path() {
+        let entries = vec![
+            PathBuf::from("/tmp/pockethle/gzga200010/sce/SCE-gizmondo.cfl"),
+            PathBuf::from("/tmp/pockethle/gzga200010/sce/sce.exe"),
+            PathBuf::from("/tmp/pockethle/gzga200010/sce/sce-gizmondo-loading.tga"),
+        ];
+        assert!(is_gizmondo_layout(
+            &entries,
+            Path::new("/tmp/pockethle/gzga200010/sce/sce.exe")
         ));
     }
 }


### PR DESCRIPTION
## What changed

This PR improves the Gizmondo / Windows Mobile graphics path using the official Gizmondo SDK archive, specifically `Examples/FrameBuffer/ddsample.cpp` and `Examples/Bluetooth/Device.cpp`.

- Models primary and off-screen DirectDraw surfaces with their own dimensions, pitch, and guest buffer.
- Implements the SDK sample's `Lock` → write pixels → `Unlock` flow.
- Implements `BltFast`, `Blt`, and `Flip` with clipped RGB565 row copies.
- Returns accurate `DDSURFACEDESC2` values, including `lpSurface`, `lPitch`, dimensions, and RGB565 masks.
- Keeps the existing GAPI framebuffer presentation path intact.

The SDK sample explicitly uses a primary surface, a 320×240 off-screen back buffer, `Lock`, `lPitch`, `Unlock`, `WaitForVerticalBlank`, and `BltFast`; those are the semantics mirrored here.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p pocket-winceapi -p pocket-kernel -p pocket-cli`
- `cargo build --release -p pocket-cli --features unicorn`

All focused tests passed: 5 CLI tests, 83 kernel tests, and 82 WinCE API tests.

The Carmageddon archive was used for investigation, but a final gameplay screenshot and a successful `tools/ai-tap-sequence.py` run are not included because the current emulator still stops before the first presented frame with `READ_UNMAPPED` at guest address `0x00000050` (`frame_counter=0`). This PR therefore contains the SDK-derived DirectDraw improvement and verified regression coverage, not a claim of confirmed Carmageddon gameplay.
