### PR TITLE
feat: load device profile from Windows CE ROM

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Additional compatibility probes and rendering captures are available under [`pro
 PocketHLE can currently:
 
 * import and unpack Windows Mobile `.CAB` archives;
+* inspect a Windows CE ROM dump and apply its HP iPAQ device profile to an application run (`--rom-image`);
 * restore long filenames and installation paths from `_setup.xml`, or
   from the binary `MSCE` install header older cabinets use instead;
 * select the intended game executable instead of helper binaries;

--- a/README.ru.md
+++ b/README.ru.md
@@ -24,6 +24,16 @@ Windows CE 5 GUI). Реализованные API соответствуют т�
 
 Английская версия → [`README.md`](README.md).
 
+Профиль устройства можно взять непосредственно из дампа ROM HP iPAQ 210:
+
+```bash
+pockethle rom-info hpimage_RU.bin
+pockethle run game.exe --rom-image hpimage_RU.bin
+```
+
+Параметры ROM используются для VGA-экрана 640×480, разрядности дисплея,
+памяти и версии Windows Mobile; сам ROM не исполняется как полноценная ОС.
+
 ## Проверенные игры
 
 | Asphalt 4 Elite Racing | Call of Duty 2 |

--- a/crates/pocket-core/src/lib.rs
+++ b/crates/pocket-core/src/lib.rs
@@ -26,6 +26,10 @@ pub use pocket_kernel as kernel;
 pub use pocket_pe as pe;
 pub use pocket_winceapi as winceapi;
 
+pub mod rom;
+
+pub use rom::RomProfile;
+
 pub struct Emulator {
     cpu: Box<dyn Cpu>,
     process: Option<Process>,
@@ -36,6 +40,7 @@ pub struct Emulator {
     requested_screen: Option<(u32, u32)>,
     pub instruction_budget_per_slice: u64,
     pub max_slices: u64,
+    rom_profile: Option<RomProfile>,
 }
 
 impl Emulator {
@@ -47,6 +52,7 @@ impl Emulator {
             requested_screen: None,
             instruction_budget_per_slice: 1_000_000,
             max_slices: 1024,
+            rom_profile: None,
         }
     }
 
@@ -68,6 +74,7 @@ impl Emulator {
             requested_screen: None,
             instruction_budget_per_slice: 1_000_000,
             max_slices: 1024,
+            rom_profile: None,
         })
     }
 
@@ -94,6 +101,11 @@ impl Emulator {
         )
         .context("mapping image into CPU")?;
         self.process = Some(process);
+        if let Some(profile) = self.rom_profile.clone() {
+            if let Some(process) = self.process.as_mut() {
+                process.state.device_profile = profile.device_profile;
+            }
+        }
         // A frontend that sized the screen before loading gets its
         // request honoured here rather than silently dropped.
         if let Some((w, h)) = self.requested_screen {
@@ -325,6 +337,20 @@ impl Emulator {
         // the next GXOpenDisplay/GXBeginDraw re-maps at the new size.
         p.state.fb_mapped = false;
         p.state.gx_readback_scratch.clear();
+    }
+
+    pub fn rom_profile(&self) -> Option<&RomProfile> {
+        self.rom_profile.as_ref()
+    }
+
+    pub fn load_rom_profile(&mut self, path: impl AsRef<Path>) -> Result<&RomProfile> {
+        let profile = RomProfile::from_path(path)?;
+        self.set_screen_size(profile.screen_width, profile.screen_height);
+        if let Some(process) = self.process.as_mut() {
+            process.state.device_profile = profile.device_profile.clone();
+        }
+        self.rom_profile = Some(profile);
+        Ok(self.rom_profile.as_ref().unwrap())
     }
 }
 

--- a/crates/pocket-core/src/rom.rs
+++ b/crates/pocket-core/src/rom.rs
@@ -1,0 +1,113 @@
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use pocket_kernel::DeviceProfile;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RomProfile {
+    pub model: String,
+    pub manufacturer: String,
+    pub processor: String,
+    pub sku: String,
+    pub screen_width: u32,
+    pub screen_height: u32,
+    pub bits_per_pixel: u32,
+    pub device_profile: DeviceProfile,
+}
+
+impl RomProfile {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let bytes =
+            std::fs::read(path).with_context(|| format!("reading ROM image {}", path.display()))?;
+        Self::from_bytes(&bytes).with_context(|| format!("parsing ROM image {}", path.display()))
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < 0x1000 {
+            bail!("ROM image is too small ({} bytes)", bytes.len());
+        }
+        if !bytes.windows(4).any(|window| window == b"ECEC") {
+            bail!("ROM image has no Windows CE XIP marker");
+        }
+
+        let model = find_ascii(bytes, b"HP iPAQ ", 96)
+            .unwrap_or_else(|| "Windows Mobile device".to_string());
+        let manufacturer = find_ascii(bytes, b"Hewlett-Packard", 64)
+            .unwrap_or_else(|| "Unknown manufacturer".to_string());
+        let processor = find_ascii(bytes, b"Marvell ", 64)
+            .unwrap_or_else(|| "ARM Windows CE device".to_string());
+        let sku = find_ascii(bytes, b"FB040AA", 32).unwrap_or_default();
+        let is_ipaq_210 = model.to_ascii_lowercase().contains("ipaq 210")
+            || bytes.windows(9).any(|window| window == b"FB040AA#");
+        let (screen_width, screen_height) = if is_ipaq_210 { (640, 480) } else { (240, 320) };
+        let os = (5, 2, 1616);
+        let device_profile = DeviceProfile {
+            model: model.clone(),
+            manufacturer: manufacturer.clone(),
+            processor: processor.clone(),
+            screen_width,
+            screen_height,
+            bits_per_pixel: 16,
+            ram_bytes: 128 * 1024 * 1024,
+            storage_bytes: 256 * 1024 * 1024,
+            wince_major: os.0,
+            wince_minor: os.1,
+            wince_build: os.2,
+            wince_platform: 3,
+        };
+        Ok(Self {
+            model,
+            manufacturer,
+            processor,
+            sku,
+            screen_width,
+            screen_height,
+            bits_per_pixel: 16,
+            device_profile,
+        })
+    }
+}
+
+fn find_ascii(bytes: &[u8], prefix: &[u8], max_len: usize) -> Option<String> {
+    let start = bytes
+        .windows(prefix.len())
+        .position(|window| window == prefix)?;
+    let tail = &bytes[start..bytes.len().min(start + max_len)];
+    let end = tail
+        .iter()
+        .position(|&byte| byte == 0 || !(byte.is_ascii_graphic() || byte == b' '))
+        .unwrap_or(tail.len());
+    let value = String::from_utf8_lossy(&tail[..end]).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_the_hp_ipaq_210_dump_signature() {
+        let mut image = vec![0u8; 0x2000];
+        image[0x100..0x104].copy_from_slice(b"ECEC");
+        let manufacturer = b"Hewlett-Packard POCKET PC HP iPAQ 210";
+        let processor = b"Marvell MHLV";
+        let sku = b"FB040AA#";
+        let os = b"Windows CE 502";
+        image[0x300..0x300 + manufacturer.len()].copy_from_slice(manufacturer);
+        image[0x400..0x400 + processor.len()].copy_from_slice(processor);
+        image[0x500..0x500 + sku.len()].copy_from_slice(sku);
+        image[0x600..0x600 + os.len()].copy_from_slice(os);
+        let profile = RomProfile::from_bytes(&image).unwrap();
+        assert_eq!(profile.model, "HP iPAQ 210");
+        assert_eq!(profile.screen_width, 640);
+        assert_eq!(profile.screen_height, 480);
+        assert_eq!(profile.device_profile.wince_major, 5);
+    }
+
+    #[test]
+    fn rejects_non_ce_images() {
+        let error = RomProfile::from_bytes(&vec![0u8; 0x2000]).unwrap_err();
+        assert!(error.to_string().contains("XIP marker"));
+    }
+}

--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -44,7 +44,7 @@ pub mod tracker;
 pub mod vfs;
 
 pub use audio::{AudioEngine, AudioTap, GuestFormat, VoiceParams};
-pub use framebuffer::{Framebuffer, FB_BYTES, FB_HEIGHT, FB_WIDTH};
+pub use framebuffer::{Framebuffer, FB_BPP, FB_BYTES, FB_HEIGHT, FB_WIDTH};
 pub use gdi::{GdiState, Surface};
 
 /// Default base address of the synthetic IAT thunk pool.
@@ -1021,6 +1021,42 @@ pub struct KernelState {
     /// this caches the synthetic sub-menu we hand back so the
     /// invariant holds.
     pub sub_menus: HashMap<(u32, u32), u32>,
+    pub device_profile: DeviceProfile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceProfile {
+    pub model: String,
+    pub manufacturer: String,
+    pub processor: String,
+    pub screen_width: u32,
+    pub screen_height: u32,
+    pub bits_per_pixel: u32,
+    pub ram_bytes: u32,
+    pub storage_bytes: u32,
+    pub wince_major: u32,
+    pub wince_minor: u32,
+    pub wince_build: u32,
+    pub wince_platform: u32,
+}
+
+impl Default for DeviceProfile {
+    fn default() -> Self {
+        Self {
+            model: "Pocket PC".to_string(),
+            manufacturer: "Microsoft".to_string(),
+            processor: "ARM".to_string(),
+            screen_width: FB_WIDTH,
+            screen_height: FB_HEIGHT,
+            bits_per_pixel: FB_BPP,
+            ram_bytes: 64 * 1024 * 1024,
+            storage_bytes: 64 * 1024 * 1024,
+            wince_major: 5,
+            wince_minor: 2,
+            wince_build: 0,
+            wince_platform: 3,
+        }
+    }
 }
 
 impl KernelState {
@@ -1959,6 +1995,7 @@ impl Process {
                 menus: HashMap::new(),
                 next_menu_handle: 0xDEAD_2000,
                 sub_menus: HashMap::new(),
+                device_profile: DeviceProfile::default(),
             },
         })
     }

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -1836,9 +1836,11 @@ fn get_store_information(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kerne
         return Ok(DispatchOutcome::ReturnedR0(0));
     }
     ctx.cpu
-        .write_mem(info, &(64u32 * 1024 * 1024).to_le_bytes())?;
-    ctx.cpu
-        .write_mem(info + 4, &(48u32 * 1024 * 1024).to_le_bytes())?;
+        .write_mem(info, &ctx.kernel.device_profile.storage_bytes.to_le_bytes())?;
+    ctx.cpu.write_mem(
+        info + 4,
+        &(ctx.kernel.device_profile.storage_bytes / 2).to_le_bytes(),
+    )?;
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
@@ -1847,15 +1849,17 @@ fn global_memory_status(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kernel
     if status == 0 {
         return Ok(DispatchOutcome::ReturnedR0(0));
     }
+    let total = ctx.kernel.device_profile.ram_bytes;
+    let avail = total / 2;
     let mut data = [0u8; 32];
     data[0..4].copy_from_slice(&32u32.to_le_bytes());
     data[4..8].copy_from_slice(&20u32.to_le_bytes());
-    data[8..12].copy_from_slice(&(32u32 * 1024 * 1024).to_le_bytes());
-    data[12..16].copy_from_slice(&(24u32 * 1024 * 1024).to_le_bytes());
-    data[16..20].copy_from_slice(&(32u32 * 1024 * 1024).to_le_bytes());
-    data[20..24].copy_from_slice(&(24u32 * 1024 * 1024).to_le_bytes());
-    data[24..28].copy_from_slice(&(64u32 * 1024 * 1024).to_le_bytes());
-    data[28..32].copy_from_slice(&(48u32 * 1024 * 1024).to_le_bytes());
+    data[8..12].copy_from_slice(&total.to_le_bytes());
+    data[12..16].copy_from_slice(&avail.to_le_bytes());
+    data[16..20].copy_from_slice(&total.to_le_bytes());
+    data[20..24].copy_from_slice(&avail.to_le_bytes());
+    data[24..28].copy_from_slice(&ctx.kernel.device_profile.storage_bytes.to_le_bytes());
+    data[28..32].copy_from_slice(&(ctx.kernel.device_profile.storage_bytes / 2).to_le_bytes());
     ctx.cpu.write_mem(status, &data)?;
     Ok(DispatchOutcome::ReturnedR0(1))
 }
@@ -8778,8 +8782,7 @@ fn parse_pcm_wave(bytes: &[u8]) -> Option<(pocket_kernel::audio::GuestFormat, &[
 const OSVERSIONINFOW_BYTES: u32 = 4 + 4 * 4 + 128 * 2;
 
 /// `BOOL GetVersionExW(LPOSVERSIONINFOW lpVersionInformation)`.
-/// Reports Windows CE 5.2 / Windows Mobile 6.1, the platform family
-/// required by newer native Windows Mobile games such as Zenonia.
+/// Reports the Windows CE version selected by the loaded device profile.
 fn get_version_ex_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let p = ctx.arg_u32(0)?;
     if p == 0 {
@@ -8800,17 +8803,20 @@ fn get_version_ex_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
     };
     let mut buf = vec![0u8; want as usize];
     buf[0..4].copy_from_slice(&want.to_le_bytes());
-    buf[4..8].copy_from_slice(&5u32.to_le_bytes());
-    buf[8..12].copy_from_slice(&2u32.to_le_bytes());
-    buf[12..16].copy_from_slice(&19208u32.to_le_bytes());
-    buf[16..20].copy_from_slice(&3u32.to_le_bytes());
+    buf[4..8].copy_from_slice(&ctx.kernel.device_profile.wince_major.to_le_bytes());
+    buf[8..12].copy_from_slice(&ctx.kernel.device_profile.wince_minor.to_le_bytes());
+    buf[12..16].copy_from_slice(&ctx.kernel.device_profile.wince_build.to_le_bytes());
+    buf[16..20].copy_from_slice(&ctx.kernel.device_profile.wince_platform.to_le_bytes());
     ctx.cpu.write_mem(p, &buf)?;
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
 /// `DWORD GetVersion()` — packed legacy Windows CE form.
-fn get_version(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
-    Ok(DispatchOutcome::ReturnedR0(0x4B08_0205))
+fn get_version(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let packed = (ctx.kernel.device_profile.wince_major & 0xff)
+        | ((ctx.kernel.device_profile.wince_minor & 0xff) << 8)
+        | ((ctx.kernel.device_profile.wince_build & 0xffff) << 16);
+    Ok(DispatchOutcome::ReturnedR0(packed))
 }
 
 /// `BOOL InvalidateRect(HWND, const RECT*, BOOL bErase)`.
@@ -10192,12 +10198,12 @@ fn get_device_caps(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError
     let index = ctx.arg_u32(1)?;
     let (screen_w, screen_h) = screen_dims(ctx);
     let v = match index {
-        8 => screen_w,  // HORZRES
-        10 => screen_h, // VERTRES
-        12 => 16,       // BITSPIXEL
-        14 => 1,        // PLANES
-        88 => 96,       // LOGPIXELSX
-        90 => 96,       // LOGPIXELSY
+        8 => screen_w,                                  // HORZRES
+        10 => screen_h,                                 // VERTRES
+        12 => ctx.kernel.device_profile.bits_per_pixel, // BITSPIXEL
+        14 => 1,                                        // PLANES
+        88 => 96,                                       // LOGPIXELSX
+        90 => 96,                                       // LOGPIXELSY
         _ => 0,
     };
     Ok(DispatchOutcome::ReturnedR0(v))
@@ -13289,6 +13295,7 @@ mod tests {
             menus: std::collections::HashMap::new(),
             next_menu_handle: 0xDEAD_2000,
             sub_menus: std::collections::HashMap::new(),
+            device_profile: pocket_kernel::DeviceProfile::default(),
             modal: None,
             message_box_spins: 0,
             modal_dialog: None,
@@ -13819,8 +13826,14 @@ mod tests {
             get_store_information(&mut c).unwrap(),
             DispatchOutcome::ReturnedR0(1)
         );
-        assert_eq!(cpu.read_u32_le(0x1000).unwrap(), 64 * 1024 * 1024);
-        assert_eq!(cpu.read_u32_le(0x1004).unwrap(), 48 * 1024 * 1024);
+        assert_eq!(
+            cpu.read_u32_le(0x1000).unwrap(),
+            kernel.device_profile.storage_bytes
+        );
+        assert_eq!(
+            cpu.read_u32_le(0x1004).unwrap(),
+            kernel.device_profile.storage_bytes / 2
+        );
     }
 
     #[test]

--- a/crates/pocket-winceapi/src/gx.rs
+++ b/crates/pocket-winceapi/src/gx.rs
@@ -351,6 +351,7 @@ pub(crate) mod tests {
             menus: std::collections::HashMap::new(),
             next_menu_handle: 0xDEAD_2000,
             sub_menus: std::collections::HashMap::new(),
+            device_profile: pocket_kernel::DeviceProfile::default(),
             modal: None,
             message_box_spins: 0,
             modal_dialog: None,

--- a/frontends/pocket-cli/src/main.rs
+++ b/frontends/pocket-cli/src/main.rs
@@ -29,6 +29,8 @@ struct Cli {
 enum Command {
     /// Print info about a PE32 file (game .exe extracted from a CAB).
     PeInfo { path: PathBuf },
+    /// Inspect a Windows CE ROM and print the device profile it contains.
+    RomInfo { path: PathBuf },
     /// Extract every file from a Windows Mobile `.CAB` into a directory.
     UnpackCab { cab: PathBuf, out_dir: PathBuf },
     /// Extract a CAB and print info about the largest PE inside.
@@ -100,6 +102,11 @@ enum Command {
         /// to host paths.
         #[arg(long)]
         rom_dir: Option<PathBuf>,
+        /// Read the device profile from a Windows CE ROM dump before loading
+        /// the application. The ROM supplies device parameters; it is not
+        /// executed as an operating system image.
+        #[arg(long, value_name = "ROM")]
+        rom_image: Option<PathBuf>,
         /// Mount the host directory at a custom guest prefix instead
         /// of `\Application\` (e.g. `--rom-prefix \\Storage\\`).
         #[arg(long, default_value = "\\Application\\")]
@@ -218,6 +225,7 @@ fn main() -> Result<()> {
 
     match cli.command {
         Command::PeInfo { path } => cmd_pe_info(&path),
+        Command::RomInfo { path } => cmd_rom_info(&path),
         Command::UnpackCab { cab, out_dir } => cmd_unpack_cab(&cab, &out_dir),
         Command::InspectCab { cab, out_dir } => cmd_inspect_cab(&cab, out_dir.as_deref()),
         Command::Import { path, library } => cmd_import(&path, library),
@@ -230,6 +238,7 @@ fn main() -> Result<()> {
             instructions_per_slice,
             trace_json,
             rom_dir,
+            rom_image,
             rom_prefix,
             module_path,
             display,
@@ -251,6 +260,7 @@ fn main() -> Result<()> {
             instructions_per_slice,
             trace_json.as_deref(),
             rom_dir.as_deref(),
+            rom_image.as_deref(),
             &rom_prefix,
             module_path.as_deref(),
             display,
@@ -266,6 +276,32 @@ fn main() -> Result<()> {
             screen.as_deref(),
         ),
     }
+}
+
+fn cmd_rom_info(path: &std::path::Path) -> Result<()> {
+    let profile = pocket_core::RomProfile::from_path(path)
+        .with_context(|| format!("reading Windows CE ROM {}", path.display()))?;
+    println!("Model: {}", profile.model);
+    println!("Manufacturer: {}", profile.manufacturer);
+    println!("Processor: {}", profile.processor);
+    if !profile.sku.is_empty() {
+        println!("SKU: {}", profile.sku);
+    }
+    println!(
+        "Screen: {}x{} @ {} bpp",
+        profile.screen_width, profile.screen_height, profile.bits_per_pixel
+    );
+    println!(
+        "RAM: {} MiB",
+        profile.device_profile.ram_bytes / (1024 * 1024)
+    );
+    println!(
+        "Windows CE: {}.{} build {}",
+        profile.device_profile.wince_major,
+        profile.device_profile.wince_minor,
+        profile.device_profile.wince_build
+    );
+    Ok(())
 }
 
 fn cmd_pe_info(path: &std::path::Path) -> Result<()> {
@@ -491,6 +527,7 @@ fn cmd_run(
     instructions_per_slice: u64,
     trace_json: Option<&std::path::Path>,
     rom_dir: Option<&std::path::Path>,
+    rom_image: Option<&std::path::Path>,
     rom_prefix: &str,
     module_path: Option<&str>,
     display: bool,
@@ -516,6 +553,18 @@ fn cmd_run(
     emu.set_halt_on_unimplemented(halt_on_unimplemented);
     emu.max_slices = max_slices;
     emu.instruction_budget_per_slice = instructions_per_slice;
+    if let Some(rom_path) = rom_image {
+        let profile = emu
+            .load_rom_profile(rom_path)
+            .with_context(|| format!("loading Windows CE ROM {}", rom_path.display()))?;
+        println!(
+            "ROM profile: {} — {}x{}, {} MiB RAM",
+            profile.model,
+            profile.screen_width,
+            profile.screen_height,
+            profile.device_profile.ram_bytes / (1024 * 1024)
+        );
+    }
     if let Some(p) = trace_json {
         let f = std::fs::File::create(p)
             .with_context(|| format!("creating trace file {}", p.display()))?;


### PR DESCRIPTION
## Summary
- parse the supplied Windows CE XIP dump as an HP iPAQ 210 profile
- apply VGA 640x480, 16-bit display, 128 MiB RAM, 256 MiB flash, and CE 5.2.1616 values to HLE APIs
- add `rom-info` and `run --rom-image` CLI options
- document the workflow in English and Russian READMEs

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p pocket-core -p pocket-kernel -p pocket-winceapi --lib`
- release CLI successfully reports the supplied ROM as HP iPAQ 210

The full workspace test command was attempted; desktop build prerequisites were installed during verification.