### PR TITLE
fix(wince): launch Jump Gizmondo build

### DIFF
--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -438,6 +438,7 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_constant(dll, "SetActiveWindow", FAKE_HWND, one_returning);
     d.register_handler(dll, "GetKeyState", get_key_state);
     d.register_handler(dll, "GetAsyncKeyState", get_async_key_state);
+    d.register_constant(dll, "ShowCursor", 0, zero_returning);
     d.register_handler(dll, "keybd_event", keybd_event);
     d.register_handler(dll, "GetFocus", get_focus);
     d.register_handler(dll, "GetCapture", get_capture);

--- a/crates/pocket-winceapi/src/ole32.rs
+++ b/crates/pocket-winceapi/src/ole32.rs
@@ -27,7 +27,11 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "CoCreateGuid", co_create_guid);
     d.register_handler(dll, "OleInitialize", s_ok);
     d.register_handler(dll, "OleUninitialize", void_returning);
-    d.register_handler(dll, "CoCreateInstance", e_notimpl);
+    d.register_handler(dll, "CoCreateInstance", co_create_instance);
+    d.register_handler("coredll.dll", "com_qi", com_query_interface);
+    d.register_handler("coredll.dll", "com_add_ref", com_add_ref);
+    d.register_handler("coredll.dll", "com_release", com_release);
+    d.register_handler("coredll.dll", "com_success", com_success);
     d.register_constant(dll, "CoGetMalloc", 0, zero_returning);
 }
 
@@ -43,13 +47,117 @@ fn zero_returning(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError
     Ok(DispatchOutcome::ReturnedR0(0))
 }
 
-/// `HRESULT CoCreateInstance` returns E_NOTIMPL for unsupported COM classes.
-fn e_notimpl(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
-    let ppv = ctx.arg_u32(4)?;
-    if ppv != 0 {
-        ctx.cpu.write_mem(ppv, &0u32.to_le_bytes())?;
+const COM_OBJECT_VTABLE_ENTRIES: usize = 32;
+
+fn com_success(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn com_add_ref(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+fn com_release(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn com_query_interface(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let object = ctx.arg_u32(0)?;
+    let iid = ctx.arg_u32(1)?;
+    let out = ctx.arg_u32(2)?;
+    if out == 0 || object == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0x8007_0057));
     }
-    Ok(DispatchOutcome::ReturnedR0(0x8000_4001))
+    if iid == 0 {
+        ctx.cpu.write_mem(out, &object.to_le_bytes())?;
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let requested = ctx.cpu.read_mem(iid, 16)?;
+    if requested.len() != 16 {
+        ctx.cpu.write_mem(out, &0u32.to_le_bytes())?;
+        return Ok(DispatchOutcome::ReturnedR0(0x8000_4002));
+    }
+    ctx.cpu.write_mem(out, &object.to_le_bytes())?;
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn com_object_vtable(ctx: &mut CallCtx<'_>) -> Result<u32, KernelError> {
+    let table = ctx
+        .kernel
+        .heap
+        .alloc((COM_OBJECT_VTABLE_ENTRIES * 4) as u32)
+        .unwrap_or(0);
+    if table == 0 {
+        return Ok(0);
+    }
+    let exports = ctx
+        .kernel
+        .dynamic_exports
+        .get(&pocket_kernel::PROCESS_INSTANCE_HANDLE);
+    let query = exports.and_then(|e| e.get("com_qi")).copied().unwrap_or(0);
+    let add_ref = exports
+        .and_then(|e| e.get("com_add_ref"))
+        .copied()
+        .unwrap_or(0);
+    let release = exports
+        .and_then(|e| e.get("com_release"))
+        .copied()
+        .unwrap_or(0);
+    let success = exports
+        .and_then(|e| e.get("com_success"))
+        .copied()
+        .unwrap_or(0);
+    for index in 0..COM_OBJECT_VTABLE_ENTRIES {
+        let address = match index {
+            0 => query,
+            1 => add_ref,
+            2 => release,
+            _ => success,
+        };
+        ctx.cpu
+            .write_mem(table + index as u32 * 4, &address.to_le_bytes())?;
+    }
+    Ok(table)
+}
+
+fn co_create_instance(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let out = ctx.arg_u32(4)?;
+    if out == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0x8007_0057));
+    }
+    let table = com_object_vtable(ctx)?;
+    if table == 0 {
+        ctx.cpu.write_mem(out, &0u32.to_le_bytes())?;
+        return Ok(DispatchOutcome::ReturnedR0(0x8000_4005));
+    }
+    let object = ctx.kernel.heap.alloc(4).unwrap_or(0);
+    if object == 0 {
+        ctx.cpu.write_mem(out, &0u32.to_le_bytes())?;
+        return Ok(DispatchOutcome::ReturnedR0(0x8000_4005));
+    }
+    ctx.cpu.write_mem(object, &table.to_le_bytes())?;
+    ctx.cpu.write_mem(out, &object.to_le_bytes())?;
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+/// `HRESULT CoCreateGuid(GUID *pguid)` — fill 16 bytes with a
+/// pseudo-random value. Most games that call this only use the
+/// resulting GUID as a unique-ish key, so we just need it to be
+/// non-zero and stable within a run.
+fn co_create_guid(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static SEED: AtomicU32 = AtomicU32::new(0xFEED_BABE);
+    let p = ctx.arg_u32(0)?;
+    if p == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0x8007_0057)); // E_INVALIDARG
+    }
+    let mut buf = [0u8; 16];
+    for chunk in buf.chunks_mut(4) {
+        let v = SEED.fetch_add(0x9E37_79B9, Ordering::Relaxed);
+        chunk.copy_from_slice(&v.to_le_bytes());
+    }
+    ctx.cpu.write_mem(p, &buf)?;
+    Ok(DispatchOutcome::ReturnedR0(0))
 }
 
 fn co_task_mem_alloc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -89,24 +197,4 @@ fn co_task_mem_realloc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelE
     }
     ctx.kernel.heap.free(p);
     Ok(DispatchOutcome::ReturnedR0(new_p))
-}
-
-/// `HRESULT CoCreateGuid(GUID *pguid)` — fill 16 bytes with a
-/// pseudo-random value. Most games that call this only use the
-/// resulting GUID as a unique-ish key, so we just need it to be
-/// non-zero and stable within a run.
-fn co_create_guid(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
-    use std::sync::atomic::{AtomicU32, Ordering};
-    static SEED: AtomicU32 = AtomicU32::new(0xFEED_BABE);
-    let p = ctx.arg_u32(0)?;
-    if p == 0 {
-        return Ok(DispatchOutcome::ReturnedR0(0x8007_0057)); // E_INVALIDARG
-    }
-    let mut buf = [0u8; 16];
-    for chunk in buf.chunks_mut(4) {
-        let v = SEED.fetch_add(0x9E37_79B9, Ordering::Relaxed);
-        chunk.copy_from_slice(&v.to_le_bytes());
-    }
-    ctx.cpu.write_mem(p, &buf)?;
-    Ok(DispatchOutcome::ReturnedR0(0))
 }

--- a/frontends/pocket-cli/src/archive.rs
+++ b/frontends/pocket-cli/src/archive.rs
@@ -907,7 +907,9 @@ const GIZMONDO_SCREEN: (u32, u32) = (320, 240);
 /// against `\Program Files\Game\`, never found the container holding
 /// every texture and scene in the game, and sat on an empty loading bar.
 fn is_gizmondo_layout(written: &[PathBuf], exe_path: &Path) -> bool {
-    has_gizmondo_title_id_pair(written) || is_alien_hominid_layout(written, exe_path)
+    has_gizmondo_title_id_pair(written)
+        || has_gizmondo_data_directory(written)
+        || is_alien_hominid_layout(written, exe_path)
 }
 
 fn has_gizmondo_title_id_pair(written: &[PathBuf]) -> bool {
@@ -921,6 +923,22 @@ fn has_gizmondo_title_id_pair(written: &[PathBuf]) -> bool {
                 .and_then(Path::file_name)
                 .and_then(|n| n.to_str())
                 .is_some_and(|parent| parent.eq_ignore_ascii_case(name))
+    })
+}
+
+fn has_gizmondo_data_directory(written: &[PathBuf]) -> bool {
+    written.iter().any(|entry| {
+        let components: Vec<_> = entry.components().collect();
+        components.windows(2).any(|pair| {
+            pair[0]
+                .as_os_str()
+                .to_str()
+                .is_some_and(is_gizmondo_title_id)
+                && pair[1]
+                    .as_os_str()
+                    .to_str()
+                    .is_some_and(|name| name.eq_ignore_ascii_case("data"))
+        })
     })
 }
 
@@ -1200,6 +1218,30 @@ mod tests {
                 "{id} should be recognised as a Gizmondo card layout"
             );
         }
+    }
+
+    #[test]
+    fn gizmondo_layout_detects_a_data_directory_without_a_serial_marker() {
+        let entries = vec![
+            PathBuf::from("/tmp/pockethle/gzga200035/data"),
+            PathBuf::from("/tmp/pockethle/jump.exe"),
+        ];
+        assert!(is_gizmondo_layout(
+            &entries,
+            Path::new("/tmp/pockethle/jump.exe")
+        ));
+    }
+
+    #[test]
+    fn gizmondo_layout_detects_files_nested_under_data() {
+        let entries = vec![
+            PathBuf::from("/tmp/pockethle/gzga200035/data/levels/tokyo1.pak"),
+            PathBuf::from("/tmp/pockethle/jump.exe"),
+        ];
+        assert!(is_gizmondo_layout(
+            &entries,
+            Path::new("/tmp/pockethle/jump.exe")
+        ));
     }
 
     #[test]

--- a/tools/ai-tap-sequence.py
+++ b/tools/ai-tap-sequence.py
@@ -35,6 +35,10 @@ def main() -> int:
         help="alias for --frames, matching the pockethle CLI spelling",
     )
     parser.add_argument("--max-frames", type=int, default=0)
+    parser.add_argument(
+        "--screen", metavar="WIDTHxHEIGHT",
+        help="emulated display geometry; defaults to 240x320",
+    )
     parser.add_argument("--message-budget", type=int, default=240)
     parser.add_argument("--max-slices", type=int, default=500_000)
     parser.add_argument("--instructions-per-slice", type=int, default=1_000_000)
@@ -54,15 +58,27 @@ def main() -> int:
         "--instructions-per-slice", str(args.instructions_per_slice),
         "--message-budget", str(args.message_budget),
     ]
+    screen_width, screen_height = 240, 320
+    if args.screen:
+        try:
+            width_text, height_text = args.screen.lower().split("x", 1)
+            screen_width, screen_height = int(width_text), int(height_text)
+            if screen_width <= 0 or screen_height <= 0:
+                raise ValueError
+        except ValueError:
+            parser.error(f"invalid --screen {args.screen!r}; expected WIDTHxHEIGHT")
+        command.extend(("--screen", f"{screen_width}x{screen_height}"))
     for tap in args.tap:
         x, separator, y = tap.partition(",")
         if not separator:
             parser.error(f"invalid --tap {tap!r}; expected X,Y")
         try:
-            if not (0 <= int(x) <= 239 and 0 <= int(y) <= 319):
+            if not (0 <= int(x) < screen_width and 0 <= int(y) < screen_height):
                 raise ValueError
         except ValueError:
-            parser.error(f"invalid --tap {tap!r}; coordinates must be X=0..239,Y=0..319")
+            parser.error(
+                f"invalid --tap {tap!r}; coordinates must be X=0..{screen_width - 1},Y=0..{screen_height - 1}"
+            )
         command.extend(("--tap", f"{int(x)},{int(y)}"))
     for key in args.key:
         command.extend(("--key", key))


### PR DESCRIPTION
## Summary

- recognize Gizmondo card images that use a `GZxx######/data` tree, including Jump's `GZGA200035` layout
- mount the extracted card at `\\SD Card\\` and report the real executable path so relative asset lookup works
- emulate the minimal COM object returned by `CoCreateInstance`, register `ShowCursor`, and let the AI tap helper pass the selected screen geometry

## Verification

- `cargo build --release -p pocket-cli --no-default-features --features unicorn`
- `cargo test -p pocket-winceapi -p pocket-cli --no-default-features --features unicorn` — 11 CLI tests and 96 WinCE API tests passed
- `python3 tools/ai-tap-sequence.py "Jump_Gizmondo_EN_Beta (1)-d7c901ac792d.zip" --screen 320x240 --max-slices 300000 --message-budget 240 --tap 319,239 --key enter --dump-frames-to jump-final-ai-tap-frames --max-frames 5` — exits cleanly, frame counter 1, captures `frame_000000.ppm`
- emulator trace reaches `eglCreateWindowSurface`, `eglSwapBuffers`, and 11 rendered frames during the extended run; no unimplemented APIs remain in the trace

## Screenshots and limitations

The emulator produced a valid 320x240 framebuffer artifact, but the supplied Jump beta's captured frame is black rather than a gameplay screenshot. The run is therefore a launch/render-path verification, not proof that the title's artwork is visible or that gameplay is reachable. This PR should not be marked fully ready until the remaining black framebuffer is diagnosed and a non-black gameplay screenshot plus a longer tap-sequence result are captured.
