### PR TITLE
fix(wince): initialize XIIZeal framebuffer startup

### DIFF
--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -1670,8 +1670,16 @@ impl Process {
                 prot |= Prot::EXEC;
             }
             let aligned = pocket_cpu::round_up_to_page(s.virtual_size.max(s.data.len() as u32));
-            cpu.map_region(image.image_base + s.virtual_address, aligned, prot)?;
-            cpu.write_mem(image.image_base + s.virtual_address, &s.data)?;
+            let base = image.image_base + s.virtual_address;
+            cpu.map_region(base, aligned, prot)?;
+            cpu.write_mem(base, &vec![0u8; aligned as usize])?;
+            cpu.write_mem(base, &s.data)?;
+            if s.data.len() < s.virtual_size as usize {
+                cpu.write_mem(
+                    base + s.data.len() as u32,
+                    &vec![0u8; s.virtual_size as usize - s.data.len()],
+                )?;
+            }
             log::debug!(
                 "mapped section {:>8} va=0x{:08x} size=0x{:x} prot={:?}",
                 s.name,
@@ -2891,6 +2899,33 @@ mod tests {
         let _ = cpu
             .read_mem(PROCESS_EXIT_TRAMPOLINE_VA, 4)
             .expect("kernel trap page must be mapped");
+    }
+
+    #[test]
+    fn mapped_sections_are_zero_filled_past_raw_image_data() {
+        let mut cpu = StubCpu::new();
+        let img = LoadedImage {
+            source_path: "test".into(),
+            machine: pocket_pe::machine::ARM,
+            subsystem: pocket_pe::subsystem::WINDOWS_CE_GUI,
+            image_base: 0x10000,
+            size_of_image: 0x3000,
+            entry_point: 0x1000,
+            sections: vec![LoadedSection {
+                name: ".data".into(),
+                virtual_address: 0x1000,
+                virtual_size: 0x1800,
+                characteristics: 0xC0000040,
+                data: vec![0xA5; 0x1200],
+            }],
+            imports: vec![],
+            exports: IndexMap::new(),
+            resources: vec![],
+            managed_runtime: None,
+        };
+        Process::map_into(img, &mut cpu, &|_, _| None, &NullDispatcher).unwrap();
+        assert_eq!(cpu.read_mem(0x12200, 0x600).unwrap(), vec![0; 0x600]);
+        assert_eq!(cpu.read_mem(0x12800, 0x800).unwrap(), vec![0; 0x800]);
     }
 }
 

--- a/crates/pocket-winceapi/src/lib.rs
+++ b/crates/pocket-winceapi/src/lib.rs
@@ -80,24 +80,36 @@ impl IgnoredDll {
     }
 }
 
-const IGNORED_DLLS: &[IgnoredDll] = &[IgnoredDll {
-    // FMOD CE, the audio middleware Xtrakt links against.
-    prefix: "fmodce",
-    returns: 1,
-    overrides: &[
-        // Xtrakt opens `Create_FmodSoundDevice` with
-        //
-        //     if (FSOUND_GetVersion() < 3.75f) -> "incompatible version"
-        //
-        // and a failure there fails the whole start-up ("Failed to
-        // initialize game."). FMOD returns the version as a `float`, and
-        // WinCE ARM is soft-float, so the bit pattern travels back in r0
-        // and the guest feeds it straight into coredll's `__lts` against
-        // the literal — hence the float encoding of 3.75 rather than the
-        // integer.
-        ("FSOUND_GetVersion", 0x4070_0000),
-    ],
-}];
+const IGNORED_DLLS: &[IgnoredDll] = &[
+    IgnoredDll {
+        // FMOD CE, the audio middleware Xtrakt links against.
+        prefix: "fmodce",
+        returns: 1,
+        overrides: &[
+            // Xtrakt opens `Create_FmodSoundDevice` with
+            //
+            //     if (FSOUND_GetVersion() < 3.75f) -> "incompatible version"
+            //
+            // and a failure there fails the whole start-up ("Failed to
+            // initialize game."). FMOD returns the version as a `float`, and
+            // WinCE ARM is soft-float, so the bit pattern travels back in r0
+            // and the guest feeds it straight into coredll's `__lts` against
+            // the literal — hence the float encoding of 3.75 rather than the
+            // integer.
+            ("FSOUND_GetVersion", 0x4070_0000),
+        ],
+    },
+    IgnoredDll {
+        // Eurosoft's framebuffer abstraction bundled with XIIZeal. The
+        // game calls only the four factories during startup and uses the
+        // returned object as an optional driver; returning a non-null
+        // sentinel keeps its fallback selection logic on the emulated GAPI
+        // path instead of dereferencing an uninitialized factory result.
+        prefix: "fblib",
+        returns: 1,
+        overrides: &[],
+    },
+];
 
 fn ignored_dll(dll: &str) -> Option<&'static IgnoredDll> {
     let dll = dll.to_ascii_lowercase();
@@ -544,6 +556,24 @@ mod tests {
                 "{name} fell through to the unimplemented path"
             );
         }
+    }
+
+    #[test]
+    fn fblib_factory_imports_are_covered_by_the_compatibility_stub() {
+        let mut d = WinCeDispatcher::new();
+        for name in [
+            "CreateGDIDriver",
+            "CreatePHALDriver",
+            "CreateGAPIDriver",
+            "DestroyFBDriver",
+        ] {
+            let t = fake_thunk("FBLib.dll", name);
+            assert!(
+                d.resolve_handler(&t).is_some(),
+                "{name} must resolve through the FBLib compatibility stub"
+            );
+        }
+        assert!(ignored_dll("FBLib.dll").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a compatibility path for XIIZeal's bundled FBLib imports
- zero-fill mapped PE section tails and page padding to match Windows CE BSS semantics
- add regression coverage for section zero-fill and FBLib factory resolution

## Validation
- `cargo test --workspace` — all tests passed
- `cargo test -p pocket-kernel -p pocket-winceapi` — 89 + 97 tests passed
- `tools/ai-tap-sequence.py` was inspected; no tap sequence was present for XIIZeal
- XIIZeal CAB inspection confirmed ARM PE and GX/FBLib imports

## Current limitation
The supplied XIIZeal build still stops before its first rendered frame: its own startup leaves `0xbabababa` in a device-table pointer and later dereferences it at `0x000199ac`. The patch removes the emulator-side FBLib resolution gap and fixes PE zero-fill semantics, but the remaining crash is in the title's driver-selection path and needs a follow-up FBLib/GAPI object ABI implementation before claiming gameplay readiness.