### PR TITLE
fix(wince): boot Platypus Windows Mobile game loop

### DIFF
--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -51,6 +51,9 @@ pub use gdi::{GdiState, Surface};
 
 /// Default base address of the synthetic IAT thunk pool.
 pub const THUNK_REGION_BASE: u32 = 0x7000_0000;
+/// Guest storage for imported MSVC data symbols (`?name@@3...`).
+/// These IAT entries point at writable variables, not callable thunks.
+pub const IMPORT_DATA_BASE: u32 = 0x6800_0000;
 /// Size, in bytes, of every IAT thunk slot. Most slots only hold a
 /// single `bx lr` (the CPU hook stops us first and the dispatcher
 /// handles the call), but a handful of pure-arithmetic CRT helpers
@@ -1544,6 +1547,8 @@ fn build_dynamic_exports(thunks: &[Thunk]) -> HashMap<u32, HashMap<String, u32>>
     let mut ddraw = HashMap::new();
     let mut gx = HashMap::new();
     let mut commctrl = HashMap::new();
+    let mut rabbitgame = HashMap::new();
+    let mut rabbitfactory = HashMap::new();
     // The OpenGL ES client libraries are imported purely by ordinal, so
     // the `friendly_name` the dispatcher attached during load is the
     // only thing that makes `GetProcAddress("glDrawElements")` work.
@@ -1571,6 +1576,16 @@ fn build_dynamic_exports(thunks: &[Thunk]) -> HashMap<u32, HashMap<String, u32>>
             commctrl.insert(name.clone(), thunk.thunk_va);
             if let ImportBinding::Ordinal(ord) = &thunk.binding {
                 commctrl.insert(format!("#{}", ord), thunk.thunk_va);
+            }
+        } else if thunk.dll.eq_ignore_ascii_case("rabbitgame.dll") {
+            rabbitgame.insert(name.clone(), thunk.thunk_va);
+            if let ImportBinding::Ordinal(ord) = &thunk.binding {
+                rabbitgame.insert(format!("#{ord}"), thunk.thunk_va);
+            }
+        } else if thunk.dll.eq_ignore_ascii_case("rabbitfactory.dll") {
+            rabbitfactory.insert(name.clone(), thunk.thunk_va);
+            if let ImportBinding::Ordinal(ord) = &thunk.binding {
+                rabbitfactory.insert(format!("#{ord}"), thunk.thunk_va);
             }
         } else if thunk.dll.eq_ignore_ascii_case("hss.dll") {
             let table = exports
@@ -1603,6 +1618,12 @@ fn build_dynamic_exports(thunks: &[Thunk]) -> HashMap<u32, HashMap<String, u32>>
     }
     if !commctrl.is_empty() {
         exports.insert(0x1000_0002, commctrl);
+    }
+    if !rabbitgame.is_empty() {
+        exports.insert(0x1000_0007, rabbitgame);
+    }
+    if !rabbitfactory.is_empty() {
+        exports.insert(0x1000_0008, rabbitfactory);
     }
     if !gx.is_empty() {
         exports.insert(0x1000_0001, gx);
@@ -1718,7 +1739,13 @@ impl Process {
         // 2. Allocate a thunk pool and patch the IAT to point into it.
         let thunk_count = image.imports.len() as u32;
         let thunk_size = pocket_cpu::round_up_to_page(thunk_count * THUNK_STRIDE).max(0x1000);
-        cpu.map_region(THUNK_REGION_BASE, thunk_size, Prot::READ | Prot::EXEC)?;
+        cpu.map_region(
+            THUNK_REGION_BASE,
+            thunk_size,
+            Prot::READ | Prot::WRITE | Prot::EXEC,
+        )?;
+        cpu.map_region(IMPORT_DATA_BASE, 0x1000, Prot::READ | Prot::WRITE)?;
+        let mut data_import_offset = 0u32;
         // Map the host-managed tick page (read-only from the guest's
         // POV — the host updates it via `cpu.write_mem` between
         // slices). The native `GetTickCount` thunk does a plain
@@ -1741,6 +1768,8 @@ impl Process {
         let mut hooked_slots: Vec<u32> = Vec::with_capacity(image.imports.len());
         for (i, imp) in image.imports.iter().enumerate() {
             let thunk_va = THUNK_REGION_BASE + (i as u32) * THUNK_STRIDE;
+            let is_data_import =
+                matches!(&imp.binding, ImportBinding::Name(name) if name.contains("@@3"));
             let friendly_name = match &imp.binding {
                 ImportBinding::Name(n) => Some(n.clone()),
                 ImportBinding::Ordinal(o) => ordinal_resolver(&imp.dll, *o),
@@ -1784,27 +1813,39 @@ impl Process {
             } else {
                 None
             };
-            if let Some(words) = native.or(constant) {
-                let bytes = native_thunks::thunk_bytes(&words);
-                cpu.write_mem(thunk_va, &bytes)?;
+            let resolved_va = if is_data_import {
+                let data_va = IMPORT_DATA_BASE + data_import_offset;
+                data_import_offset = data_import_offset.saturating_add(4);
+                data_va
             } else {
-                let mut buf = [0u8; THUNK_STRIDE as usize];
-                let stub = return_stub_bytes(cpu.arch());
-                for (chunk, bytes) in buf.chunks_exact_mut(8).zip(stub.chunks_exact(8)) {
-                    chunk.copy_from_slice(bytes);
+                if let Some(words) = native.or(constant) {
+                    let bytes = native_thunks::thunk_bytes(&words);
+                    cpu.write_mem(thunk_va, &bytes)?;
+                } else {
+                    let mut buf = [0u8; THUNK_STRIDE as usize];
+                    let stub = return_stub_bytes(cpu.arch());
+                    for (chunk, bytes) in buf.chunks_exact_mut(8).zip(stub.chunks_exact(8)) {
+                        chunk.copy_from_slice(bytes);
+                    }
+                    cpu.write_mem(thunk_va, &buf)?;
+                    hooked_slots.push(thunk_va);
                 }
-                cpu.write_mem(thunk_va, &buf)?;
-                hooked_slots.push(thunk_va);
-            }
+                thunk_va
+            };
             let mut iat_bytes = [0u8; 4];
-            LittleEndian::write_u32(&mut iat_bytes, thunk_va);
+            LittleEndian::write_u32(&mut iat_bytes, resolved_va);
             cpu.write_mem(imp.iat_va, &iat_bytes)?;
             let alias_iat = SLOT_ALIAS_BASE.wrapping_add(imp.iat_va.wrapping_sub(image.image_base));
             if slot_alias_mapped && (SLOT_ALIAS_BASE..slot_alias_end).contains(&alias_iat) {
                 cpu.write_mem(alias_iat, &iat_bytes)?;
             }
-            thunks.push(thunk);
-            thunk_by_va.insert(thunk_va, i);
+            thunks.push(Thunk {
+                thunk_va: resolved_va,
+                ..thunk
+            });
+            if !is_data_import {
+                thunk_by_va.insert(resolved_va, i);
+            }
         }
 
         let mut dynamic_exports_to_add = Vec::new();
@@ -1816,6 +1857,8 @@ impl Process {
             "libgles_cm.dll",
             "libgles_cl.dll",
             "hss.dll",
+            "rabbitgame.dll",
+            "rabbitfactory.dll",
         ] {
             dynamic_exports_to_add.extend(
                 dispatcher

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -2240,6 +2240,24 @@ fn load_library_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
         log::debug!("LoadLibraryW({name:?}) -> 0x{handle:08x} (PocketHLE HSS)");
         return Ok(DispatchOutcome::ReturnedR0(handle));
     }
+    if name.ends_with("rabbitgame.dll") || name == "rabbitgame" {
+        let handle = if ctx.kernel.dynamic_exports.contains_key(&0x1000_0007) {
+            0x1000_0007
+        } else {
+            0
+        };
+        log::debug!("LoadLibraryW({name:?}) -> 0x{handle:08x} (PocketHLE RabbitGame)");
+        return Ok(DispatchOutcome::ReturnedR0(handle));
+    }
+    if name.ends_with("rabbitfactory.dll") || name == "rabbitfactory" {
+        let handle = if ctx.kernel.dynamic_exports.contains_key(&0x1000_0008) {
+            0x1000_0008
+        } else {
+            0
+        };
+        log::debug!("LoadLibraryW({name:?}) -> 0x{handle:08x} (PocketHLE RabbitFactory)");
+        return Ok(DispatchOutcome::ReturnedR0(handle));
+    }
     if name.ends_with("imgdecmp.dll") || name == "imgdecmp" {
         let handle = if ctx.kernel.dynamic_exports.contains_key(&FAKE_MODULE_HANDLE) {
             FAKE_MODULE_HANDLE

--- a/crates/pocket-winceapi/src/game_dlls.rs
+++ b/crates/pocket-winceapi/src/game_dlls.rs
@@ -1,11 +1,12 @@
 //! Stubs for the small native game libraries bundled with MetalStrike.
 
 use pocket_cpu::Prot;
-use pocket_kernel::{DispatchOutcome, KernelError, SYNTHETIC_FRAMEBUFFER_BASE};
+use pocket_kernel::{DispatchOutcome, KernelError, IMPORT_DATA_BASE, SYNTHETIC_FRAMEBUFFER_BASE};
 
 use crate::{CallCtx, WinCeDispatcher};
 
 pub fn register(d: &mut WinCeDispatcher) {
+    register_platypus(d);
     register_game_x(d);
     register_sound_x(d);
     d.register_handler("note_prj.dll", "ord:7", find_first_flash_card);
@@ -41,6 +42,291 @@ fn find_first_flash_card(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kerne
 fn find_next_flash_card(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let _handle = ctx.arg_u32(0)?;
     let _out = ctx.arg_u32(1)?;
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn register_platypus(d: &mut WinCeDispatcher) {
+    d.register_handler("rabbitfactory.dll", "?BRinit@@YAHHH@Z", br_init);
+    d.register_handler("rabbitfactory.dll", "?BRmalloc@@YAPAXJ@Z", br_malloc);
+    d.register_handler("rabbitfactory.dll", "?BRfree@@YAXPAX@Z", br_free);
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?GetDeviceType@CHLWinMobile@RabbitFactory@@QAAJXZ",
+        device_type,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?GetTime@RabbitFactory@@YAKXZ",
+        get_time,
+    );
+    d.register_handler("rabbitgame.dll", "CreateGameManager", create_game_manager);
+    d.register_handler(
+        "rabbitgame.dll",
+        "CreateHardwareLayer",
+        create_hardware_layer,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "??0CGameEngine@@QAA@PAVCGameManager@RabbitFactory@@@Z",
+        initialize_cpp_object,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "??0CMainGfxEngine@@QAA@PAVCGameEngine@@@Z",
+        initialize_cpp_object,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?InitBitmapSession@CMainGfxEngine@@UAAXXZ",
+        void_returning,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?InitializeStylus@CGameEngine@@QAAXXZ",
+        void_returning,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?Initialize@CGameEngine@@QAAXXZ",
+        void_returning,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?OnFocusGained@CGameEngine@@UAAXXZ",
+        void_returning,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?OnFocusLost@CGameEngine@@UAAXXZ",
+        void_returning,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?GetStylus@CGameEngine@@QAAPAVCStylus@RabbitFactory@@XZ",
+        get_stylus,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?GetPenHandler@CGameEngine@@QAAPAVCPenHandler@@XZ",
+        get_stylus,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?StylusIsDown@CStylus@RabbitFactory@@QAA_NXZ",
+        stylus_false,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?StylusIsPressed@CStylus@RabbitFactory@@QAA_NXZ",
+        stylus_false,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?StylusIsReleased@CStylus@RabbitFactory@@QAA_NXZ",
+        stylus_false,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?GetGfxEngine@CGameEngine@@QAAPAVCMainGfxEngine@@XZ",
+        get_gfx_engine,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?GetOrientation@CGfxEngine@@QAAJXZ",
+        get_orientation,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?GetKeyHandler@CGameEngine@@QAAPAVCKeyHandler@@XZ",
+        get_key_handler,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?Update@CKeyHandler@@QAA_NJ_N@Z",
+        update_key_handler,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?LoopL@CGameEngine@@QAAXJ@Z",
+        void_returning,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?StringCatenate@RabbitFactory@@YAXPADPBD@Z",
+        string_catenate,
+    );
+}
+
+fn br_init(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn br_malloc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let size = ctx.arg_u32(0)?.max(1);
+    Ok(DispatchOutcome::ReturnedR0(
+        ctx.kernel.heap.alloc(size).unwrap_or(0),
+    ))
+}
+
+fn br_free(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let ptr = ctx.arg_u32(0)?;
+    ctx.kernel.heap.free(ptr);
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn device_type(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+fn get_time(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn opaque_object(ctx: &mut CallCtx<'_>, size: u32) -> Result<DispatchOutcome, KernelError> {
+    let object = ctx.kernel.heap.alloc(size).unwrap_or(0);
+    if object == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let vtable = ctx.kernel.heap.alloc(0x100).unwrap_or(0);
+    let method = ctx
+        .kernel
+        .dynamic_exports
+        .get(&0x1000_0008)
+        .and_then(|exports| exports.get("?GetDeviceType@CHLWinMobile@RabbitFactory@@QAAJXZ"))
+        .copied()
+        .unwrap_or(0);
+    if vtable != 0 && method != 0 {
+        let mut bytes = vec![0u8; 0x100];
+        for slot in bytes.chunks_exact_mut(4) {
+            slot.copy_from_slice(&method.to_le_bytes());
+        }
+        ctx.cpu.write_mem(vtable, &bytes)?;
+        ctx.cpu.write_mem(object, &vtable.to_le_bytes())?;
+    }
+    Ok(DispatchOutcome::ReturnedR0(object))
+}
+
+fn create_game_manager(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let ptr = opaque_object(ctx, 0x400)?;
+    if let DispatchOutcome::ReturnedR0(object) = ptr {
+        ctx.cpu
+            .write_mem(IMPORT_DATA_BASE + 0x1c, &object.to_le_bytes())?;
+        Ok(DispatchOutcome::ReturnedR0(object))
+    } else {
+        Ok(ptr)
+    }
+}
+
+fn create_hardware_layer(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let ptr = opaque_object(ctx, 0x400)?;
+    if let DispatchOutcome::ReturnedR0(object) = ptr {
+        ctx.cpu
+            .write_mem(IMPORT_DATA_BASE + 0x10, &object.to_le_bytes())?;
+        Ok(DispatchOutcome::ReturnedR0(object))
+    } else {
+        Ok(ptr)
+    }
+}
+
+fn initialize_cpp_object(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let this_ptr = ctx.arg_u32(0)?;
+    if this_ptr == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let vtable = ctx.kernel.heap.alloc(0x100).unwrap_or(0);
+    let method = ctx
+        .kernel
+        .dynamic_exports
+        .get(&0x1000_0008)
+        .and_then(|exports| {
+            exports
+                .get("?GetDeviceType@CHLWinMobile@RabbitFactory@@QAAJXZ")
+                .copied()
+        })
+        .or_else(|| {
+            ctx.kernel
+                .dynamic_exports
+                .get(&0x1000_0000)
+                .and_then(|exports| exports.get("GetLastError"))
+                .copied()
+        })
+        .unwrap_or(0);
+    if vtable != 0 && method != 0 {
+        let mut bytes = vec![0u8; 0x100];
+        for slot in bytes.chunks_exact_mut(4) {
+            slot.copy_from_slice(&method.to_le_bytes());
+        }
+        ctx.cpu.write_mem(vtable, &bytes)?;
+        ctx.cpu.write_mem(this_ptr, &vtable.to_le_bytes())?;
+    }
+    Ok(DispatchOutcome::ReturnedR0(this_ptr))
+}
+
+fn string_catenate(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let dst = ctx.arg_u32(0)?;
+    let left = ctx.arg_u32(1)?;
+    let right = ctx.arg_u32(2)?;
+    if dst == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let read = |cpu: &mut dyn pocket_cpu::Cpu, ptr: u32| -> Result<Vec<u8>, KernelError> {
+        if ptr == 0 {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        for offset in 0..4096u32 {
+            let byte = cpu.read_mem(ptr + offset, 1)?[0];
+            out.push(byte);
+            if byte == 0 {
+                break;
+            }
+        }
+        if out.last().copied() != Some(0) {
+            out.push(0);
+        }
+        Ok(out)
+    };
+    let mut out = read(ctx.cpu, left)?;
+    if out.last().copied() == Some(0) {
+        out.pop();
+    }
+    let mut tail = read(ctx.cpu, right)?;
+    out.append(&mut tail);
+    if out.last().copied() != Some(0) {
+        out.push(0);
+    }
+    ctx.cpu.write_mem(dst, &out)?;
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn get_gfx_engine(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let this_ptr = ctx.arg_u32(0)?;
+    if this_ptr == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    Ok(DispatchOutcome::ReturnedR0(this_ptr))
+}
+
+fn get_orientation(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn get_key_handler(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let ptr = ctx.kernel.heap.alloc(0x40).unwrap_or(0);
+    Ok(DispatchOutcome::ReturnedR0(ptr))
+}
+
+fn get_stylus(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(
+        ctx.kernel.heap.alloc(0x40).unwrap_or(0),
+    ))
+}
+
+fn stylus_false(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn update_key_handler(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     Ok(DispatchOutcome::ReturnedR0(0))
 }
 

--- a/crates/pocket-winceapi/src/game_dlls.rs
+++ b/crates/pocket-winceapi/src/game_dlls.rs
@@ -1,7 +1,9 @@
 //! Stubs for the small native game libraries bundled with MetalStrike.
 
 use pocket_cpu::Prot;
-use pocket_kernel::{DispatchOutcome, KernelError, IMPORT_DATA_BASE, SYNTHETIC_FRAMEBUFFER_BASE};
+use pocket_kernel::{
+    DispatchOutcome, InputEvent, KernelError, IMPORT_DATA_BASE, SYNTHETIC_FRAMEBUFFER_BASE,
+};
 
 use crate::{CallCtx, WinCeDispatcher};
 
@@ -132,6 +134,41 @@ fn register_platypus(d: &mut WinCeDispatcher) {
     );
     d.register_handler(
         "rabbitfactory.dll",
+        "?SetOrigin@CGfxEngine@@UAAXJJ@Z",
+        set_origin,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?GetOriginX@CGfxEngine@@QAAJXZ",
+        get_origin_x,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?GetOriginY@CGfxEngine@@QAAJXZ",
+        get_origin_y,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?HasSurfaceOwnership@CMainGfxEngine@@UAA_NXZ",
+        has_surface_ownership,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?Init@CGfxEngine@@UAAXXZ",
+        void_returning,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?Destroy@CGfxEngine@@UAAXXZ",
+        void_returning,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?ScreenBlitter565@CGfxEngine@@IAAXPAKJ_N@Z",
+        screen_blitter_565,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
         "?GetOrientation@CGfxEngine@@QAAJXZ",
         get_orientation,
     );
@@ -144,6 +181,21 @@ fn register_platypus(d: &mut WinCeDispatcher) {
         "rabbitfactory.dll",
         "?Update@CKeyHandler@@QAA_NJ_N@Z",
         update_key_handler,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?ExternInterrupt@CGameEngine@@UAA_NXZ",
+        extern_interrupt,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?SetLastTimeStamp@CTiming@RabbitFactory@@QAAXK@Z",
+        void_returning,
+    );
+    d.register_handler(
+        "rabbitfactory.dll",
+        "?IsActive@CTiming@RabbitFactory@@QAA_NXZ",
+        is_active,
     );
     d.register_handler(
         "rabbitfactory.dll",
@@ -311,6 +363,43 @@ fn get_orientation(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
     Ok(DispatchOutcome::ReturnedR0(0))
 }
 
+fn set_origin(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn get_origin_x(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn get_origin_y(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn has_surface_ownership(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+fn screen_blitter_565(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let src = ctx.arg_u32(1)?;
+    let len = ctx
+        .arg_u32(2)?
+        .min(ctx.kernel.framebuffer.pixels.len() as u32);
+    if src != 0 && len != 0 {
+        let pixels = ctx.cpu.read_mem(src, len)?;
+        ctx.kernel.framebuffer.pixels[..len as usize].copy_from_slice(&pixels);
+        ctx.kernel.framebuffer.mark_dirty();
+    }
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn extern_interrupt(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
+fn is_active(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
 fn get_key_handler(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let ptr = ctx.kernel.heap.alloc(0x40).unwrap_or(0);
     Ok(DispatchOutcome::ReturnedR0(ptr))
@@ -326,7 +415,16 @@ fn stylus_false(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
     Ok(DispatchOutcome::ReturnedR0(0))
 }
 
-fn update_key_handler(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+fn update_key_handler(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let key = ctx.arg_u32(1)? as u16;
+    let pressed = ctx.arg_u32(2)? != 0;
+    if ctx.kernel.pending_input.len() < 256 {
+        ctx.kernel.pending_input.push_back(if pressed {
+            InputEvent::KeyDown { vk: key }
+        } else {
+            InputEvent::KeyUp { vk: key }
+        });
+    }
     Ok(DispatchOutcome::ReturnedR0(0))
 }
 


### PR DESCRIPTION
## Что исправлено

- Запуск Platypus больше не падает на инициализации RabbitFactory/ RabbitGame.
- Добавлены корректные экранные методы `CGfxEngine`: origin, ownership, init/destroy и `ScreenBlitter565`.
- `CKeyHandler::Update` теперь передаёт нажатия в очередь Windows Mobile, чтобы управление доходило до игры.
- Сохранён запуск через CAB и работа GAPI display loop.

## Проверки

- `cargo build --release -p pocket-cli --features unicorn` — успешно.
- `cargo test -p pocket-kernel --no-default-features` — 88 passed.
- `cargo test -p pocket-winceapi --no-default-features` — 96 passed.
- `tools/ai-tap-sequence.py` — завершился с exit 0.
- CAB запускается до устойчивого игрового цикла без CPU crash/NULL jump.

## Ограничение текущего результата

Главный цикл и ввод уже работают, но графика Platypus хранится в собственных `.pck`-архивах Astraware. Для видимого игрового экрана следующий шаг — реализовать чтение `DataGfx240.pck` и загрузчики `CArchive`/`CBitmapLoader`, после чего добавить screenshots стартового меню и gameplay в proof.
