### PR TITLE
feat: add configurable game memory corruption

### DIFF
--- a/crates/pocket-core/src/lib.rs
+++ b/crates/pocket-core/src/lib.rs
@@ -23,6 +23,7 @@ use pocket_winceapi::{resolve_ordinal, WinCeDispatcher};
 pub use pocket_cab as cab;
 pub use pocket_cpu as cpu;
 pub use pocket_kernel as kernel;
+pub use pocket_kernel::corrupt::CorruptionOptions;
 pub use pocket_pe as pe;
 pub use pocket_winceapi as winceapi;
 
@@ -36,6 +37,7 @@ pub struct Emulator {
     requested_screen: Option<(u32, u32)>,
     pub instruction_budget_per_slice: u64,
     pub max_slices: u64,
+    pub corruption: CorruptionOptions,
 }
 
 impl Emulator {
@@ -47,6 +49,7 @@ impl Emulator {
             requested_screen: None,
             instruction_budget_per_slice: 1_000_000,
             max_slices: 1024,
+            corruption: CorruptionOptions::default(),
         }
     }
 
@@ -68,6 +71,7 @@ impl Emulator {
             requested_screen: None,
             instruction_budget_per_slice: 1_000_000,
             max_slices: 1024,
+            corruption: CorruptionOptions::default(),
         })
     }
 
@@ -93,6 +97,8 @@ impl Emulator {
             &self.dispatcher,
         )
         .context("mapping image into CPU")?;
+        let mut process = process;
+        process.corruptor = pocket_kernel::corrupt::Corruptor::new(self.corruption);
         self.process = Some(process);
         // A frontend that sized the screen before loading gets its
         // request honoured here rather than silently dropped.

--- a/crates/pocket-kernel/src/corrupt.rs
+++ b/crates/pocket-kernel/src/corrupt.rs
@@ -1,0 +1,213 @@
+use std::time::Instant;
+
+use pocket_cpu::Cpu;
+
+use crate::Heap;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct CorruptionOptions {
+    pub enabled: bool,
+    pub interval_frames: u32,
+    pub bytes_per_burst: u32,
+    pub max_offset: Option<u32>,
+    pub seed: u64,
+}
+
+impl Default for CorruptionOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_frames: 400,
+            bytes_per_burst: 1,
+            max_offset: None,
+            seed: 0x6a09_e667_f3bc_c909,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Rng {
+    state: u64,
+}
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Self {
+            state: seed ^ 0x9e37_79b9_7f4a_7c15,
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    fn below(&mut self, bound: u64) -> u64 {
+        self.next_u64() % bound
+    }
+}
+
+pub struct Corruptor {
+    options: CorruptionOptions,
+    rng: Rng,
+    ticks_since_burst: u64,
+    total_corrupted: u64,
+    last_log: Option<Instant>,
+}
+
+impl Default for Corruptor {
+    fn default() -> Self {
+        Self::new(CorruptionOptions {
+            enabled: false,
+            ..CorruptionOptions::default()
+        })
+    }
+}
+
+impl Corruptor {
+    pub fn new(options: CorruptionOptions) -> Self {
+        Self {
+            rng: Rng::new(options.seed),
+            options,
+            ticks_since_burst: 0,
+            total_corrupted: 0,
+            last_log: None,
+        }
+    }
+
+    pub fn options(&self) -> CorruptionOptions {
+        self.options
+    }
+
+    pub fn total_corrupted(&self) -> u64 {
+        self.total_corrupted
+    }
+
+    pub fn tick(&mut self, cpu: &mut dyn Cpu, heap: &Heap) {
+        if !self.options.enabled {
+            return;
+        }
+        self.ticks_since_burst = self.ticks_since_burst.saturating_add(1);
+        if self.ticks_since_burst < u64::from(self.options.interval_frames.max(1)) {
+            return;
+        }
+        self.ticks_since_burst = 0;
+        self.blast(cpu, heap);
+    }
+
+    fn blast(&mut self, cpu: &mut dyn Cpu, heap: &Heap) {
+        let allocations = heap.live_allocations();
+        let ranges: Vec<(u32, u32)> = allocations
+            .into_iter()
+            .filter_map(|(base, size)| {
+                let eligible = match self.options.max_offset {
+                    Some(limit) if limit > 0 => size.min(limit),
+                    _ => size,
+                };
+                (eligible > 0).then_some((base, eligible))
+            })
+            .collect();
+        let total_bytes: u64 = ranges.iter().map(|(_, size)| u64::from(*size)).sum();
+        if total_bytes == 0 {
+            return;
+        }
+
+        let mut corrupted = 0u64;
+        for _ in 0..self.options.bytes_per_burst.max(1) {
+            let mut pick = self.rng.below(total_bytes);
+            let mut address = None;
+            for &(base, size) in &ranges {
+                let size = u64::from(size);
+                if pick < size {
+                    address = Some(base.wrapping_add(pick as u32));
+                    break;
+                }
+                pick -= size;
+            }
+            let Some(address) = address else { continue };
+            let value = self.rng.next_u64() as u8;
+            if cpu.write_mem(address, &[value]).is_ok() {
+                corrupted = corrupted.saturating_add(1);
+            }
+        }
+        self.total_corrupted = self.total_corrupted.saturating_add(corrupted);
+        if corrupted > 0 && self.last_log.map_or(true, |t| t.elapsed().as_secs() >= 1) {
+            log::debug!(
+                "corrupted {corrupted} guest byte(s) across {} live allocation(s); {} total",
+                ranges.len(),
+                self.total_corrupted
+            );
+            self.last_log = Some(Instant::now());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocket_cpu::{stub::StubCpu, Cpu, Prot};
+
+    fn setup(size: u32) -> (StubCpu, Heap, u32) {
+        let mut cpu = StubCpu::new();
+        cpu.map_region(0x5000_0000, 0x1000, Prot::READ | Prot::WRITE)
+            .unwrap();
+        let mut heap = Heap::new(0x5000_0000, 0x1000);
+        let ptr = heap.alloc(size).unwrap();
+        cpu.write_mem(ptr, &vec![0xaa; size as usize]).unwrap();
+        (cpu, heap, ptr)
+    }
+
+    #[test]
+    fn deterministic_for_seed() {
+        let mut a = Rng::new(12345);
+        let mut b = Rng::new(12345);
+        for _ in 0..1000 {
+            assert_eq!(a.next_u64(), b.next_u64());
+        }
+    }
+
+    #[test]
+    fn disabled_does_nothing() {
+        let (mut cpu, heap, ptr) = setup(256);
+        let mut corruptor = Corruptor::new(CorruptionOptions {
+            enabled: false,
+            interval_frames: 1,
+            ..CorruptionOptions::default()
+        });
+        corruptor.tick(&mut cpu, &heap);
+        assert_eq!(cpu.read_mem(ptr, 256).unwrap(), vec![0xaa; 256]);
+        assert_eq!(corruptor.total_corrupted(), 0);
+    }
+
+    #[test]
+    fn interval_gates_burst() {
+        let (mut cpu, heap, ptr) = setup(256);
+        let mut corruptor = Corruptor::new(CorruptionOptions {
+            interval_frames: 3,
+            ..CorruptionOptions::default()
+        });
+        corruptor.tick(&mut cpu, &heap);
+        corruptor.tick(&mut cpu, &heap);
+        assert_eq!(corruptor.total_corrupted(), 0);
+        corruptor.tick(&mut cpu, &heap);
+        assert_eq!(corruptor.total_corrupted(), 1);
+        assert_ne!(cpu.read_mem(ptr, 256).unwrap(), vec![0xaa; 256]);
+    }
+
+    #[test]
+    fn max_offset_stays_inside_prefix() {
+        let (mut cpu, heap, ptr) = setup(256);
+        let mut corruptor = Corruptor::new(CorruptionOptions {
+            interval_frames: 1,
+            max_offset: Some(4),
+            ..CorruptionOptions::default()
+        });
+        corruptor.tick(&mut cpu, &heap);
+        let bytes = cpu.read_mem(ptr, 256).unwrap();
+        assert!(bytes[..4].iter().any(|&byte| byte != 0xaa));
+        assert!(bytes[4..].iter().all(|&byte| byte == 0xaa));
+    }
+}

--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -34,6 +34,7 @@ use pocket_pe::{machine, ImportBinding, ImportSymbol, LoadedImage, ResourceEntry
 
 pub mod audio;
 pub mod controls;
+pub mod corrupt;
 pub mod font;
 pub mod framebuffer;
 pub mod gapi;
@@ -1528,6 +1529,13 @@ impl Heap {
     pub fn free_bytes(&self) -> u32 {
         self.free.iter().map(|(_, s)| *s).sum()
     }
+
+    pub fn live_allocations(&self) -> Vec<(u32, u32)> {
+        self.live
+            .iter()
+            .map(|(&base, &size)| (base, size))
+            .collect()
+    }
 }
 
 /// Fake `HMODULE` for `libGLES_CM.dll`, the Common profile.
@@ -1622,6 +1630,7 @@ pub struct Process {
     pub stack_top: u32,
     pub stack_size: u32,
     pub state: KernelState,
+    pub corruptor: corrupt::Corruptor,
 }
 
 impl Process {
@@ -2077,6 +2086,7 @@ impl Process {
                 next_menu_handle: 0xDEAD_2000,
                 sub_menus: HashMap::new(),
             },
+            corruptor: corrupt::Corruptor::default(),
         })
     }
 
@@ -2319,6 +2329,7 @@ pub fn run_main_loop_with_hook(
         let t_cpu = prof.mark();
         let stop = cpu.run_until_hook(pc, instruction_budget_per_slice);
         prof.add_cpu(t_cpu);
+        process.corruptor.tick(cpu, &process.state.heap);
         let stop = match stop {
             Ok(s) => s,
             Err(e) => {

--- a/frontends/pocket-cli/src/main.rs
+++ b/frontends/pocket-cli/src/main.rs
@@ -73,6 +73,21 @@ enum Command {
         /// CPU backend.
         #[arg(long, default_value = DEFAULT_CPU_BACKEND)]
         cpu: CpuBackend,
+        /// Enable RTCV-style guest-memory corruption every N slices. The default is 400.
+        #[arg(long, default_value_t = 400)]
+        corrupt_interval: u32,
+        /// Disable RTCV-style guest-memory corruption.
+        #[arg(long, default_value_t = false)]
+        no_corrupt_game: bool,
+        /// Number of bytes overwritten per corruption burst.
+        #[arg(long, default_value_t = 1)]
+        corrupt_intensity: u32,
+        /// Seed used to make the corruption stream reproducible.
+        #[arg(long, default_value_t = 0x6a09_e667_f3bc_c909u64)]
+        corrupt_seed: u64,
+        /// Limit corruption to the first N bytes of each allocation.
+        #[arg(long)]
+        corrupt_max_offset: Option<u32>,
         /// Halt as soon as the guest calls an unimplemented API.
         #[arg(long, default_value_t = false)]
         halt_on_unimplemented: bool,
@@ -228,6 +243,11 @@ fn main() -> Result<()> {
         Command::Run {
             path,
             cpu,
+            corrupt_interval,
+            no_corrupt_game,
+            corrupt_intensity,
+            corrupt_seed,
+            corrupt_max_offset,
             halt_on_unimplemented,
             max_slices,
             instructions_per_slice,
@@ -249,6 +269,11 @@ fn main() -> Result<()> {
         } => cmd_run(
             &path,
             cpu,
+            corrupt_interval,
+            no_corrupt_game,
+            corrupt_intensity,
+            corrupt_seed,
+            corrupt_max_offset,
             halt_on_unimplemented,
             max_slices,
             instructions_per_slice,
@@ -489,6 +514,11 @@ fn cmd_render_demo(out_path: &std::path::Path) -> Result<()> {
 fn cmd_run(
     path: &std::path::Path,
     backend: CpuBackend,
+    corrupt_interval: u32,
+    no_corrupt_game: bool,
+    corrupt_intensity: u32,
+    corrupt_seed: u64,
+    corrupt_max_offset: Option<u32>,
     halt_on_unimplemented: bool,
     max_slices: u64,
     instructions_per_slice: u64,
@@ -516,6 +546,24 @@ fn cmd_run(
         #[cfg(feature = "unicorn")]
         CpuBackend::Mips => Emulator::with_unicorn_cpu_for_arch(pocket_core::cpu::Arch::Mips)?,
     };
+    emu.corruption = pocket_core::CorruptionOptions {
+        enabled: !no_corrupt_game,
+        interval_frames: corrupt_interval.max(1),
+        bytes_per_burst: corrupt_intensity.max(1),
+        max_offset: corrupt_max_offset,
+        seed: corrupt_seed,
+    };
+    println!(
+        "Game corruption: {} (interval={}, intensity={}, seed=0x{:x})",
+        if emu.corruption.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        },
+        emu.corruption.interval_frames,
+        emu.corruption.bytes_per_burst,
+        emu.corruption.seed,
+    );
     emu.set_halt_on_unimplemented(halt_on_unimplemented);
     emu.max_slices = max_slices;
     emu.instruction_budget_per_slice = instructions_per_slice;


### PR DESCRIPTION
## Summary
- add RTCV-style guest-memory corruption with a deterministic seed
- enable it by default with `--corrupt-interval=400`
- expose CLI controls for disabling, intensity, seed, and offset limits

## Verification
- `cargo check -p pocket-kernel -p pocket-core -p pocket-winceapi -p pocket-cli --no-default-features`
- `cargo test -p pocket-kernel corrupt --no-default-features`
- `cargo test -p pocket-winceapi --no-default-features`
- `cargo fmt --all -- --check`
- `git diff --check`