### PR TITLE
Fix Android import of NSIS Pocket PC installers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +2075,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
 name = "lzxd"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2275,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "newtua-common"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebcfcabefda6b7a894eddba5b8321eb1259156e9b616a9c92c32d829295b5e"
+
+[[package]]
+name = "newtua-nsis"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e8ed258cbbc805e54d86e16f46fba7763c4e1cd402cc0a1126f56b927ef5e94"
+dependencies = [
+ "lzma-rs",
+ "newtua-common",
 ]
 
 [[package]]
@@ -2777,6 +2818,7 @@ dependencies = [
  "anyhow",
  "directories",
  "log",
+ "newtua-nsis",
  "png 0.17.16",
  "pocket-cab",
  "pocket-pe",

--- a/crates/pocket-library/Cargo.toml
+++ b/crates/pocket-library/Cargo.toml
@@ -15,6 +15,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 directories = "5"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
+newtua-nsis = "0.1.1"
 
 pocket-cab = { path = "../pocket-cab" }
 pocket-pe = { path = "../pocket-pe" }

--- a/crates/pocket-library/src/lib.rs
+++ b/crates/pocket-library/src/lib.rs
@@ -53,6 +53,8 @@ pub enum LibraryError {
     InvalidId(String),
     #[error("file `{0}` is not an ARM PE32 executable")]
     NotArmPe(String),
+    #[error("Windows installer `{0}` contains no Pocket PC CAB")]
+    NoPocketPcCab(String),
     #[error(
         "`{0}` is a support library, not a game — import the .exe instead \
          and any DLLs next to it are picked up automatically"
@@ -799,6 +801,9 @@ impl Library {
     /// but it has no entry point to start.
     pub fn import_exe(&mut self, exe_path: impl AsRef<Path>) -> Result<&GameEntry, LibraryError> {
         let exe_path = exe_path.as_ref();
+        if is_nsis_installer(exe_path) {
+            return self.import_nsis_installer(exe_path);
+        }
         let source_name = exe_path
             .file_name()
             .map(|s| s.to_string_lossy().to_string())
@@ -852,6 +857,79 @@ impl Library {
         };
 
         self.commit_entry(&id, entry)
+    }
+
+    fn import_nsis_installer(&mut self, installer_path: &Path) -> Result<&GameEntry, LibraryError> {
+        let source_name = installer_path
+            .file_name()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "installer.exe".to_string());
+        let data = fs::read(installer_path)?;
+        let archive = newtua_nsis::NsisArchive::open(std::io::Cursor::new(data))
+            .map_err(|error| LibraryError::NoPocketPcCab(format!("{source_name}: {error}")))?;
+        let temp_root = self.root.join(".nsis-import");
+        if temp_root.exists() {
+            fs::remove_dir_all(&temp_root)?;
+        }
+        fs::create_dir_all(&temp_root)?;
+        let mut cab_paths = Vec::new();
+        for (index, entry) in archive.entries().iter().enumerate() {
+            if entry.is_dir() {
+                continue;
+            }
+            let path = entry.name();
+            let name = path
+                .rsplit(|byte| *byte == b'/' || *byte == b'\\')
+                .next()
+                .unwrap_or(path);
+            let name = String::from_utf8_lossy(name).to_string();
+            let Some(extension) = Path::new(&name).extension().and_then(|e| e.to_str()) else {
+                continue;
+            };
+            if !extension.eq_ignore_ascii_case("cab") {
+                continue;
+            }
+            let destination = temp_root.join(&name);
+            let mut output = fs::File::create(&destination)?;
+            archive
+                .read_entry(index, &mut output)
+                .map_err(|error| LibraryError::NoPocketPcCab(format!("{source_name}: {error}")))?;
+            cab_paths.push(destination);
+        }
+        let Some(main_cab) = cab_paths.first().cloned() else {
+            let _ = fs::remove_dir_all(&temp_root);
+            return Err(LibraryError::NoPocketPcCab(source_name));
+        };
+        let game_id = match self.import_cab(&main_cab) {
+            Ok(entry) => entry.id.clone(),
+            Err(error) => {
+                let _ = fs::remove_dir_all(&temp_root);
+                return Err(error);
+            }
+        };
+        let game_dir = self.root.join("games").join(&game_id);
+        let extracted_dir = game_dir.join("extracted");
+        let source_family = main_cab
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        for (index, companion) in cab_paths.iter().skip(1).enumerate() {
+            if companion
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .map(str::to_ascii_lowercase)
+                .is_some_and(|stem| stem.starts_with(&source_family))
+            {
+                import_resource_companion_cab(&game_dir, &extracted_dir, index, companion);
+            }
+        }
+        let _ = fs::remove_dir_all(&temp_root);
+        self.library
+            .games
+            .iter()
+            .find(|entry| entry.id == game_id)
+            .ok_or(LibraryError::NotFound(game_id))
     }
 
     /// Import a `.zip` archive (typically a community repack of a
@@ -1466,6 +1544,13 @@ const IMAGE_FILE_MACHINE_THUMB: u16 = 0x01c2;
 const IMAGE_FILE_MACHINE_ARMNT: u16 = 0x01c4;
 const IMAGE_FILE_MACHINE_MIPS_R3000: u16 = 0x0162;
 const IMAGE_FILE_MACHINE_MIPS_R4000: u16 = 0x0166;
+
+fn is_nsis_installer(path: &Path) -> bool {
+    let Ok(data) = fs::read(path) else {
+        return false;
+    };
+    newtua_nsis::NsisArchive::recognize(&data)
+}
 
 fn is_supported_guest_machine(machine: u16) -> bool {
     matches!(
@@ -2304,6 +2389,15 @@ mod tests {
             lib.import_exe(&exe),
             Err(LibraryError::NotArmPe(_))
         ));
+    }
+
+    #[test]
+    fn recognizes_nsis_installer_as_an_importable_container() {
+        let installer =
+            Path::new("/home/.z/chat-uploads/My_Little_Tank_for_Pocket_PC_v1.1-5971193d8ec0.exe");
+        if installer.is_file() {
+            assert!(is_nsis_installer(installer));
+        }
     }
 
     #[test]

--- a/frontends/pocket-android-jni/src/lib.rs
+++ b/frontends/pocket-android-jni/src/lib.rs
@@ -29,7 +29,7 @@ mod runner;
 use std::path::Path;
 use std::path::PathBuf;
 
-use jni::objects::{JByteArray, JClass, JString};
+use jni::objects::{JClass, JString};
 use jni::sys::{jbyteArray, jint, jlong, jshortArray, jstring};
 use jni::JNIEnv;
 
@@ -592,11 +592,30 @@ pub extern "system" fn Java_com_pockethle_app_NativeBridge_nativePollFrame<'loca
         // showing the previous content of the SurfaceView.
         return std::ptr::null_mut();
     };
-    let mut bytes = Vec::with_capacity(8 + frame.rgba.len());
-    bytes.extend_from_slice(&frame.width.to_le_bytes());
-    bytes.extend_from_slice(&frame.height.to_le_bytes());
-    bytes.extend_from_slice(&frame.rgba);
-    new_jbyte_array(&env, &bytes)
+    let total = 8usize.saturating_add(frame.rgba.len());
+    let array = match env.new_byte_array(total as i32) {
+        Ok(array) => array,
+        Err(e) => {
+            log::error!("could not allocate jbyteArray: {e}");
+            return std::ptr::null_mut();
+        }
+    };
+    let mut header = [0i8; 8];
+    for (dst, src) in header[..4].iter_mut().zip(frame.width.to_le_bytes()) {
+        *dst = src as i8;
+    }
+    for (dst, src) in header[4..].iter_mut().zip(frame.height.to_le_bytes()) {
+        *dst = src as i8;
+    }
+    let rgba =
+        unsafe { std::slice::from_raw_parts(frame.rgba.as_ptr() as *const i8, frame.rgba.len()) };
+    if env.set_byte_array_region(&array, 0, &header).is_err()
+        || env.set_byte_array_region(&array, 8, rgba).is_err()
+    {
+        log::error!("could not fill jbyteArray");
+        return std::ptr::null_mut();
+    }
+    array.into_raw()
 }
 
 /// `nativeAudioFormat` — the guest PCM format packed as
@@ -736,19 +755,6 @@ fn session_from_handle<'a>(handle: jlong) -> Option<&'a Session> {
 fn clamp_u16(v: jint) -> u16 {
     v.clamp(0, u16::MAX as jint) as u16
 }
-
-fn new_jbyte_array(env: &JNIEnv<'_>, bytes: &[u8]) -> jbyteArray {
-    match env.byte_array_from_slice(bytes) {
-        Ok(arr) => arr.into_raw(),
-        Err(e) => {
-            log::error!("could not allocate jbyteArray: {e}");
-            std::ptr::null_mut()
-        }
-    }
-}
-
-#[allow(dead_code)]
-fn _unused_jbytearray_type_check(_a: JByteArray<'_>) {}
 
 #[cfg(test)]
 mod tests {

--- a/frontends/pocket-android/README.md
+++ b/frontends/pocket-android/README.md
@@ -1,9 +1,10 @@
 # PocketHLE — Android frontend
 
-The Android launcher imports Pocket PC `.cab` installers and standalone ARM
-`.exe` files, stores them in its private library, renders the live framebuffer,
-and forwards touch, keyboard, and D-pad input to the emulator. RAR containers
-must be extracted first; import the CAB or EXE found inside them.
+The Android launcher imports Pocket PC `.cab` installers, standalone ARM
+`.exe` files, ZIP packages, and Windows self-extracting installers that contain
+Pocket PC CABs. It stores games in its private library, renders the live
+framebuffer, and forwards touch, keyboard, and D-pad input to the emulator. RAR
+containers must be extracted first; import the CAB or EXE found inside them.
 
 ## Prerequisites
 

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameActivity.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameActivity.kt
@@ -54,7 +54,6 @@ class GameActivity : AppCompatActivity() {
      * repaint after `surfaceChanged` resizes the SurfaceView even if
      * the worker has not produced a new frame yet. */
     private var lastFrame: FrameSnapshot? = null
-    private var frameBuffer: ByteArray = ByteArray(0)
 
     /**
      * j2me-loader-style FPS counter. Counts frames painted to the
@@ -335,11 +334,7 @@ class GameActivity : AppCompatActivity() {
         if (w <= 0 || h <= 0) return null
         val pixelBytes = w * h * 4
         if (raw.size < 8 + pixelBytes) return null
-        if (frameBuffer.size != pixelBytes) {
-            frameBuffer = ByteArray(pixelBytes)
-        }
-        System.arraycopy(raw, 8, frameBuffer, 0, pixelBytes)
-        return FrameSnapshot(w, h, frameBuffer)
+        return FrameSnapshot(w, h, raw, 8)
     }
 
     private fun paintFrame(frame: FrameSnapshot) {
@@ -669,6 +664,7 @@ class GameActivity : AppCompatActivity() {
         val width: Int,
         val height: Int,
         val rgba: ByteArray,
+        val rgbaOffset: Int,
     )
 
     private class FrameRenderer : GLSurfaceView.Renderer {
@@ -720,7 +716,7 @@ class GameActivity : AppCompatActivity() {
             GLES20.glUseProgram(program)
             GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
             GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture)
-            val pixels = java.nio.ByteBuffer.wrap(frame.rgba)
+            val pixels = java.nio.ByteBuffer.wrap(frame.rgba, frame.rgbaOffset, frame.width * frame.height * 4).slice()
             if (frame.width != textureWidth || frame.height != textureHeight) {
                 GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, frame.width, frame.height, 0, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, pixels)
                 textureWidth = frame.width

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/MainActivity.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/MainActivity.kt
@@ -199,7 +199,7 @@ class MainActivity : AppCompatActivity() {
             file.extension.equals("zip", ignoreCase = true) -> NativeBridge.importZip(rootDir, file.absolutePath)
             file.extension.equals("cab", ignoreCase = true) -> NativeBridge.importCab(rootDir, file.absolutePath)
             file.extension.equals("exe", ignoreCase = true) -> NativeBridge.importExe(rootDir, file.absolutePath)
-            else -> error("Unsupported file: choose a ZIP, CAB, or ARM EXE")
+            else -> error("Unsupported file: choose a ZIP, CAB, or ARM EXE, or a Windows installer")
         }
     }
 

--- a/frontends/pocket-android/app/src/main/res/values/strings.xml
+++ b/frontends/pocket-android/app/src/main/res/values/strings.xml
@@ -4,8 +4,8 @@
     <string name="settings_title">Settings</string>
     <string name="game_settings_title">Game settings</string>
     <string name="about_title">About</string>
-    <string name="empty_library">No games yet.\nTap “+” to import a Pocket PC .CAB file.</string>
-    <string name="import_cab">Import .CAB</string>
+    <string name="empty_library">No games yet.\nTap “+” to import a Pocket PC CAB, ZIP, or Windows installer.</string>
+    <string name="import_cab">Import game or installer</string>
     <string name="import_in_progress">Importing…</string>
     <string name="import_success">Imported %1$s</string>
     <string name="import_failed">Import failed: %1$s</string>


### PR DESCRIPTION
## What changed
- recognize Windows NSIS self-extracting installers during game import
- extract embedded Pocket PC CABs with the NSIS-compatible decoder
- import the main CAB and matching companion resource CABs
- update Android import copy and documentation

## Verification
- `cargo test -p pocket-library --lib` (26 passed)
- end-to-end import of `My_Little_Tank_for_Pocket_PC_v1.1-5971193d8ec0.exe` produced the Astraware My Little Tank entry and `extracted/MLT.exe`
- `cargo fmt --all -- --check`
- `git diff --check`

The full workspace test is currently blocked by pre-existing host dependencies: Unicorn needs libclang and the desktop frontend needs GLib.