### PR TITLE
fix(wince): launch Richard Burns Rally Gizmondo build

### DIFF
--- a/crates/pocket-gles/src/consts.rs
+++ b/crates/pocket-gles/src/consts.rs
@@ -89,6 +89,12 @@ pub const GL_NEAREST_MIPMAP_LINEAR: u32 = 0x2702;
 pub const GL_LINEAR_MIPMAP_LINEAR: u32 = 0x2703;
 pub const GL_REPEAT: u32 = 0x2901;
 pub const GL_CLAMP_TO_EDGE: u32 = 0x812F;
+pub const GL_TEXTURE_MIN_LOD_SGIS: u32 = 0x813A;
+pub const GL_TEXTURE_MAX_LOD_SGIS: u32 = 0x813B;
+pub const GL_TEXTURE_BASE_LEVEL_SGIS: u32 = 0x813C;
+pub const GL_TEXTURE_MAX_LEVEL_SGIS: u32 = 0x813D;
+pub const GL_MAX_TEXTURE_LOD_BIAS_EXT: u32 = 0x84FD;
+pub const GL_TEXTURE_LOD_BIAS_EXT: u32 = 0x8501;
 
 // ---- glGetString names --------------------------------------------------
 pub const GL_VENDOR: u32 = 0x1F00;

--- a/crates/pocket-gles/src/texture.rs
+++ b/crates/pocket-gles/src/texture.rs
@@ -209,6 +209,11 @@ impl Texture {
                 }
                 None => false,
             },
+            GL_TEXTURE_MIN_LOD_SGIS
+            | GL_TEXTURE_MAX_LOD_SGIS
+            | GL_TEXTURE_BASE_LEVEL_SGIS
+            | GL_TEXTURE_MAX_LEVEL_SGIS
+            | GL_TEXTURE_LOD_BIAS_EXT => true,
             _ => false,
         }
     }

--- a/crates/pocket-kernel/src/vfs.rs
+++ b/crates/pocket-kernel/src/vfs.rs
@@ -157,6 +157,9 @@ struct Mount {
     read_only: bool,
 }
 
+/// The Gizmondo registration service device exposed as `REG1:`.
+const REGISTRATION_SERVICE_DEVICE: &str = "reg1:";
+
 /// Mount-point + open-handle table.
 pub struct Vfs {
     mounts: Vec<Mount>,
@@ -168,6 +171,8 @@ pub struct Vfs {
     /// handle only ever reaches `DeviceIoControl` and `CloseHandle`.
     volumes: HashMap<u32, OpenVolume>,
     next_handle: u32,
+    /// Handles opened on the Gizmondo registration service device.
+    registration: std::collections::HashSet<u32>,
     /// Directory relative guest paths are resolved against.
     ///
     /// Windows CE has no per-process working directory, but Pocket PC
@@ -193,6 +198,7 @@ impl Vfs {
             volumes: HashMap::new(),
             decoders: HashMap::new(),
             next_handle: HANDLE_BASE,
+            registration: std::collections::HashSet::new(),
             default_dir: "\\".to_string(),
         }
     }
@@ -574,6 +580,16 @@ impl Vfs {
             );
             return Some(h);
         }
+        // Gizmondo titles open REG1: to query the device registration
+        // service before creating their first window. HLE has no licensing
+        // service, but the device must exist so the title can continue.
+        if normalised.rsplit('/').next() == Some(REGISTRATION_SERVICE_DEVICE) {
+            let h = self.next_handle;
+            self.next_handle += 1;
+            self.registration.insert(h);
+            log::debug!("vfs.open({guest_path:?}) -> registration service handle 0x{h:08x}");
+            return Some(h);
+        }
         // A volume handle has to be checked for before the regular file
         // path: `Vol:` is not a file, so `resolve` would fall through to
         // its recursive basename search and then fail to open the result.
@@ -648,11 +664,18 @@ impl Vfs {
     }
 
     pub fn read(&mut self, handle: u32, buf: &mut [u8]) -> Option<usize> {
+        if self.registration.contains(&handle) {
+            buf.fill(0);
+            return Some(0);
+        }
         let of = self.handles.get_mut(&handle)?;
         of.file.read(buf).ok()
     }
 
     pub fn write(&mut self, handle: u32, buf: &[u8]) -> Option<usize> {
+        if self.registration.contains(&handle) {
+            return Some(buf.len());
+        }
         let of = self.handles.get_mut(&handle)?;
         of.file.write(buf).ok()
     }
@@ -684,6 +707,7 @@ impl Vfs {
         self.handles.remove(&handle).is_some()
             || self.volumes.remove(&handle).is_some()
             || self.decoders.remove(&handle).is_some()
+            || self.registration.remove(&handle)
     }
 
     /// Flush and close every open handle, returning how many were closed.
@@ -701,11 +725,17 @@ impl Vfs {
         self.handles.clear();
         self.volumes.clear();
         self.decoders.clear();
+        self.registration.clear();
         n
     }
 
     pub fn is_open(&self, handle: u32) -> bool {
         self.handles.contains_key(&handle)
+    }
+
+    /// Whether `handle` came from opening the Gizmondo registration service.
+    pub fn is_registration_service(&self, handle: u32) -> bool {
+        self.registration.contains(&handle)
     }
 
     /// The volume a handle was opened on, when it came from a `Vol:`

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -99,6 +99,9 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "GetCommandLineW", get_command_line_w);
     d.register_handler(dll, "GetModuleHandleW", get_module_handle_w);
     d.register_handler(dll, "GetModuleFileNameW", get_module_file_name_w);
+    d.register_handler(dll, "GetFileVersionInfoSizeW", get_file_version_info_size_w);
+    d.register_handler(dll, "GetFileVersionInfoW", get_file_version_info_w);
+    d.register_handler(dll, "VerQueryValueW", ver_query_value_w);
     d.register_handler(dll, "GetModuleInformation", get_module_information);
     d.register_handler(dll, "GetProcAddress", get_proc_address_a);
     d.register_handler(dll, "GetProcAddressA", get_proc_address_a);
@@ -1573,6 +1576,156 @@ fn report_gsfailure(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
     Ok(DispatchOutcome::Halt)
 }
 
+fn version_resource(kernel: &KernelState) -> Option<(u32, u32)> {
+    kernel.resource_scopes().find_map(|(entries, base)| {
+        entries
+            .iter()
+            .find(|entry| entry.ty == ResourceKey::Id(16) && entry.name == ResourceKey::Id(1))
+            .map(|entry| (base.wrapping_add(entry.data_rva), entry.size))
+    })
+}
+
+fn get_file_version_info_size_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let file_ptr = ctx.arg_u32(0)?;
+    let handle_ptr = ctx.arg_u32(1)?;
+    let file = if file_ptr == 0 {
+        String::new()
+    } else {
+        String::from_utf16_lossy(&read_wstr(ctx, file_ptr, 260)?)
+    };
+    let Some((_, size)) = version_resource(ctx.kernel) else {
+        log::debug!("GetFileVersionInfoSizeW({file:?}) -> 0");
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    };
+    if handle_ptr != 0 {
+        ctx.cpu.write_mem(handle_ptr, &0u32.to_le_bytes())?;
+    }
+    log::debug!("GetFileVersionInfoSizeW({file:?}) -> {size}");
+    Ok(DispatchOutcome::ReturnedR0(size))
+}
+
+fn get_file_version_info_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let file_ptr = ctx.arg_u32(0)?;
+    let _handle = ctx.arg_u32(1)?;
+    let length = ctx.arg_u32(2)?;
+    let data = ctx.arg_u32(3)?;
+    let file = if file_ptr == 0 {
+        String::new()
+    } else {
+        String::from_utf16_lossy(&read_wstr(ctx, file_ptr, 260)?)
+    };
+    let Some((source, size)) = version_resource(ctx.kernel) else {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    };
+    if data == 0 || length < size {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let bytes = ctx.cpu.read_mem(source, size)?;
+    ctx.cpu.write_mem(data, &bytes)?;
+    log::debug!("GetFileVersionInfoW({file:?}, {length}) -> {size}");
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+#[derive(Clone, Copy)]
+struct VersionNode {
+    end: usize,
+    value: usize,
+    value_bytes: usize,
+    value_units: u32,
+}
+
+fn version_word(bytes: &[u8], at: usize) -> Option<u16> {
+    let end = at.checked_add(2)?;
+    Some(u16::from_le_bytes(bytes.get(at..end)?.try_into().ok()?))
+}
+
+fn version_node(bytes: &[u8], start: usize) -> Option<(String, VersionNode)> {
+    let length = version_word(bytes, start)? as usize;
+    let value_units = version_word(bytes, start + 2)? as u32;
+    let kind = version_word(bytes, start + 4)?;
+    let end = start.checked_add(length)?.min(bytes.len());
+    let mut key_at = start.checked_add(6)?;
+    let mut key = Vec::new();
+    loop {
+        let ch = version_word(bytes, key_at)?;
+        key_at = key_at.checked_add(2)?;
+        if ch == 0 {
+            break;
+        }
+        key.push(ch);
+    }
+    let value = (key_at + 3) & !3;
+    let value_bytes = if kind == 1 {
+        value_units.checked_mul(2)? as usize
+    } else {
+        value_units as usize
+    };
+    if value.checked_add(value_bytes)? > end {
+        return None;
+    }
+    Some((
+        String::from_utf16_lossy(&key),
+        VersionNode {
+            end,
+            value,
+            value_bytes,
+            value_units,
+        },
+    ))
+}
+
+fn version_child(bytes: &[u8], parent: VersionNode, wanted: &str) -> Option<(String, VersionNode)> {
+    let mut at = (parent.value + parent.value_bytes + 3) & !3;
+    while at + 6 <= parent.end {
+        let (key, node) = version_node(bytes, at)?;
+        if key.eq_ignore_ascii_case(wanted) {
+            return Some((key, node));
+        }
+        if node.end <= at {
+            break;
+        }
+        at = (node.end + 3) & !3;
+    }
+    None
+}
+
+fn ver_query_value_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let block = ctx.arg_u32(0)?;
+    let subblock = ctx.arg_u32(1)?;
+    let value_out = ctx.arg_u32(2)?;
+    let length_out = ctx.arg_u32(3)?;
+    if block == 0 || subblock == 0 || value_out == 0 || length_out == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let query = String::from_utf16_lossy(&read_wstr(ctx, subblock, 260)?);
+    let Some((_, size)) = version_resource(ctx.kernel) else {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    };
+    let bytes = ctx.cpu.read_mem(block, size)?;
+    let Some((_, mut node)) = version_node(&bytes, 0) else {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    };
+    let mut value_offset = node.value;
+    for part in query.split('\\').filter(|part| !part.is_empty()) {
+        let Some((_, child)) = version_child(&bytes, node, part) else {
+            return Ok(DispatchOutcome::ReturnedR0(0));
+        };
+        value_offset = child.value;
+        node = child;
+    }
+    let units = if query == "\\" {
+        node.value_bytes as u32
+    } else {
+        node.value_units
+    };
+    ctx.cpu.write_mem(
+        value_out,
+        &block.wrapping_add(value_offset as u32).to_le_bytes(),
+    )?;
+    ctx.cpu.write_mem(length_out, &units.to_le_bytes())?;
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
 // ---------- process / time ----------
 
 fn get_tick_count(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -1950,6 +2103,19 @@ fn device_io_control(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErr
     let out_buf = ctx.arg_u32(4)?;
     let out_len = ctx.arg_u32(5)?;
     let returned_p = ctx.arg_u32(6)?;
+
+    if ctx.kernel.vfs.is_registration_service(handle) {
+        if out_buf != 0 && out_len > 0 {
+            ctx.cpu.write_mem(out_buf, &vec![0u8; out_len as usize])?;
+        }
+        if returned_p != 0 {
+            ctx.cpu.write_mem(returned_p, &0u32.to_le_bytes())?;
+        }
+        log::debug!(
+            "DeviceIoControl(REG1: h=0x{handle:08x}, code=0x{code:08x}, in_len={in_len}, out_len={out_len}) -> TRUE"
+        );
+        return Ok(DispatchOutcome::ReturnedR0(1));
+    }
 
     let Some(volume) = ctx.kernel.vfs.volume(handle) else {
         // MAS1 is the Gizmondo's hardware MP3 decoder. The official SDK

--- a/crates/pocket-winceapi/src/gles.rs
+++ b/crates/pocket-winceapi/src/gles.rs
@@ -949,7 +949,7 @@ fn gl_get_string(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
         pocket_gles::GL_RENDERER => "PocketHLE Software Rasterizer",
         pocket_gles::GL_VERSION => "OpenGL ES-CL 1.1",
         pocket_gles::GL_EXTENSIONS => {
-            "GL_AMD_compressed_ATC_texture GL_ATI_texture_compression_atitc GL_EXT_texture_compression_s3tc GL_OES_compressed_paletted_texture"
+            "GL_AMD_compressed_ATC_texture GL_ATI_texture_compression_atitc GL_EXT_texture_compression_s3tc GL_EXT_texture_compression_dxt1 GL_EXT_texture_lod_bias GL_SGIS_texture_lod GL_OES_compressed_paletted_texture"
         }
         _ => {
             with_ctx(|c| c.set_error(pocket_gles::GL_INVALID_ENUM));


### PR DESCRIPTION
## Summary
- emulate the Gizmondo `REG1:` registration-service device so the game can complete startup checks
- implement WinCE version-resource queries used for `GFSDK.dll`, `libGLES_CM.dll`, `NVDDI.dll`, and the game executable
- accept Gizmondo SGIS/EXT texture LOD parameters and advertise the extensions exposed by the Gizmondo SDK

## Verification
- `cargo build --release -j 1 -p pocket-cli --features unicorn` — passed
- `cargo test -j 1 -p pocket-gles -p pocket-winceapi -p pocket-core -p pocket-cli` — 220 unit tests passed; repository doctest invocation is incompatible with the installed Cargo/rustdoc because it passes `--check-cfg` without `-Z unstable-options`
- `tools/ai-tap-sequence.py /home/.z/chat-uploads/Richard-Burns-Rally_Gizmondo_EN-f5ed733d15ed.zip --cpu unicorn --message-budget 0 --max-slices 1000000 --max-frames 12` — passed, clean exit, `frame_counter=12`, 12 frames captured, 9 unique frames

## Visual proof
- Contact sheet: `rbr-contact-sheet.png`
- The run reaches the rendered window/message path and produces non-black, changing framebuffer output at the Gizmondo 320x240 landscape resolution.

Known non-fatal warnings in the headless environment: no ALSA output device, `timeBeginPeriod`, and `GetDiskFreeSpaceExW` are still unimplemented. They do not prevent launch or rendering in this proof.
