### PR TITLE
fix(gizmondo): advance Carmageddon past WinCE startup

### DIFF
--- a/crates/pocket-cpu/src/lib.rs
+++ b/crates/pocket-cpu/src/lib.rs
@@ -253,6 +253,10 @@ pub trait Cpu {
     /// range would be trapped instead of executing its own code.
     fn add_code_hook_range(&mut self, lo: u32, hi: u32) -> Result<(), CpuError>;
 
+    /// Register a code hook for an instruction that the backend may not
+    /// decode natively. The hook is reported with the instruction address.
+    fn add_instruction_hook(&mut self, va: u32) -> Result<(), CpuError>;
+
     /// Run starting at `start_va` until either an [`StopReason::Hook`]
     /// fires, `max_instructions` is reached, or `request_stop` is
     /// called from another hook. Set `max_instructions` to `0` to run

--- a/crates/pocket-cpu/src/stub.rs
+++ b/crates/pocket-cpu/src/stub.rs
@@ -105,6 +105,9 @@ impl Cpu for StubCpu {
         self.hook_ranges.push((lo, hi));
         Ok(())
     }
+    fn add_instruction_hook(&mut self, va: u32) -> Result<(), CpuError> {
+        self.add_code_hook(va)
+    }
 
     fn run_until_hook(
         &mut self,

--- a/crates/pocket-cpu/src/unicorn.rs
+++ b/crates/pocket-cpu/src/unicorn.rs
@@ -428,6 +428,10 @@ impl Cpu for UnicornCpu {
         self.add_code_hook_range(va, va)
     }
 
+    fn add_instruction_hook(&mut self, va: u32) -> Result<(), CpuError> {
+        self.add_code_hook(va)
+    }
+
     fn add_code_hook_range(&mut self, lo: u32, hi: u32) -> Result<(), CpuError> {
         let last = self.last_hook.clone();
         let stop = self.stop_requested.clone();

--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -179,6 +179,9 @@ pub const MODULE_REGION_END: u32 = 0x4000_0000;
 
 /// "bx lr" in ARM mode (little endian).
 pub const ARM_BX_LR: [u8; 4] = [0x1e, 0xff, 0x2f, 0xe1];
+/// Windows CE's ARM debugger breakpoint instruction.
+pub const WINCE_BREAKPOINT: u32 = 0xe600_0010;
+
 /// `jr ra; nop` in MIPS32 little-endian mode.
 pub const MIPS_JR_RA: [u8; 8] = [0x08, 0x00, 0xe0, 0x03, 0x00, 0x00, 0x00, 0x00];
 
@@ -1698,6 +1701,21 @@ impl Process {
             start < slot_alias_end && start.saturating_add(size) > SLOT_ALIAS_BASE
         });
         let slot_alias_mapped = !image_overlaps_slot;
+        if cpu.arch() == Arch::Arm {
+            for section in &image.sections {
+                if !section.is_executable() {
+                    continue;
+                }
+                let section_start = image.image_base + section.virtual_address;
+                for (offset, word) in section.data.windows(4).enumerate() {
+                    if u32::from_le_bytes(word.try_into().expect("4-byte window"))
+                        == WINCE_BREAKPOINT
+                    {
+                        cpu.add_instruction_hook(section_start + offset as u32)?;
+                    }
+                }
+            }
+        }
         if slot_alias_mapped {
             cpu.map_region(
                 SLOT_ALIAS_BASE,
@@ -2449,6 +2467,19 @@ pub fn run_main_loop_with_hook(
                     continue;
                 }
 
+                let is_wince_breakpoint = cpu
+                    .read_mem(addr, 4)
+                    .ok()
+                    .and_then(|bytes| bytes.try_into().ok())
+                    .map(u32::from_le_bytes)
+                    == Some(WINCE_BREAKPOINT);
+                if is_wince_breakpoint {
+                    cpu.write_reg(ArmReg::Pc, addr + 4)?;
+                    pc = addr + 4;
+                    log::debug!("WinCE debugger breakpoint treated as a no-op at 0x{addr:08x}");
+                    continue;
+                }
+
                 let outcome = match process.find_thunk_and_state(addr) {
                     Some((thunk, state)) => {
                         // Split borrow: `thunk` borrows
@@ -2786,6 +2817,10 @@ mod tests {
 
         fn add_code_hook_range(&mut self, lo: u32, hi: u32) -> Result<(), CpuError> {
             self.inner.add_code_hook_range(lo, hi)
+        }
+
+        fn add_instruction_hook(&mut self, va: u32) -> Result<(), CpuError> {
+            self.inner.add_instruction_hook(va)
         }
 
         fn run_until_hook(

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -133,6 +133,8 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "__utos", soft_utos);
     d.register_handler(dll, "__stoi", soft_stoi);
     d.register_handler(dll, "__stou", soft_stou);
+    d.register_handler(dll, "__stoi64", soft_stoi64);
+    d.register_handler(dll, "__stou64", soft_stou64);
     d.register_handler(dll, "__stod", soft_stod);
     d.register_handler(dll, "__addd", soft_addd);
     d.register_handler(dll, "__subd", soft_subd);
@@ -271,6 +273,7 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "GetFileSize", get_file_size);
     d.register_handler(dll, "GlobalMemoryStatus", global_memory_status);
     d.register_handler(dll, "GetStoreInformation", get_store_information);
+    d.register_handler(dll, "GetDiskFreeSpaceExW", get_disk_free_space_ex_w);
     d.register_handler(dll, "#323", get_store_information);
     d.register_handler(dll, "DeviceIoControl", device_io_control);
     d.register_handler(dll, "SetFilePointer", set_file_pointer);
@@ -1087,6 +1090,7 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "GetThreadLocale", get_thread_locale);
     d.register_handler(dll, "GetLocaleInfoW", get_locale_info_w);
     d.register_handler(dll, "GetACP", get_acp);
+    d.register_constant(dll, "ShowCursor", 1, one_returning);
     d.register_handler(dll, "CreateCursor", create_cursor);
     d.register_handler(dll, "DestroyCursor", destroy_cursor);
 
@@ -1930,6 +1934,24 @@ fn get_store_information(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kerne
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
+fn get_disk_free_space_ex_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let free_available = ctx.arg_u32(1)?;
+    let total_bytes = ctx.arg_u32(2)?;
+    let free_bytes = ctx.arg_u32(3)?;
+    const TOTAL: u64 = 64 * 1024 * 1024;
+    const FREE: u64 = 48 * 1024 * 1024;
+    for (ptr, value) in [
+        (free_available, FREE),
+        (total_bytes, TOTAL),
+        (free_bytes, FREE),
+    ] {
+        if ptr != 0 {
+            ctx.cpu.write_mem(ptr, &value.to_le_bytes())?;
+        }
+    }
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
 /// `BOOL DeviceIoControl(HANDLE h, DWORD code, void* in, DWORD in_len,
 ///                       void* out, DWORD out_len, DWORD* returned,
 ///                       OVERLAPPED* overlapped)`
@@ -2651,6 +2673,18 @@ fn soft_stou(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
         v as u32
     };
     Ok(DispatchOutcome::ReturnedR0(r))
+}
+fn soft_stoi64(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(ret_i64(read_f64(ctx, 0)? as i64))
+}
+fn soft_stou64(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let v = read_f64(ctx, 0)?;
+    let r = if v < 0.0 || !v.is_finite() {
+        0
+    } else {
+        v as u64
+    };
+    Ok(DispatchOutcome::ReturnedR0R1(r as u32, (r >> 32) as u32))
 }
 fn soft_stod(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     Ok(ret_f64(read_f32(ctx, 0)? as f64))


### PR DESCRIPTION
## Summary

- Recognize and safely advance the Windows CE ARM debugger breakpoint instruction `0xE6000010`, which Carmageddon uses during startup.
- Add the missing `__stoi64` / `__stou64`, `GetDiskFreeSpaceExW`, and `ShowCursor` compatibility handlers.
- Keep the breakpoint hook backend-neutral across Unicorn and the stub CPU.

## Validation

- `cargo test -p pocket-cpu --lib` — 2 passed
- `cargo test -p pocket-kernel --lib` — 88 passed
- `cargo test -p pocket-winceapi --lib` — 97 passed
- `cargo build --release -p pocket-cli --features unicorn` — passed
- `tools/ai-tap-sequence.py` reaches EGL initialization and captures 3 frames at 320x240 before the remaining Carmageddon payload-loading fault.

## Remaining issue

The game now gets through startup, card validation, nested `data.zip` opening, and graphical initialization, but still faults while loading payload assets at `0x00534C00`. The PR deliberately records this partial-but-material progress rather than claiming gameplay readiness.