### PR TITLE
style: format DirectDraw helper

### DIFF
--- a/crates/pocket-cab/src/lib.rs
+++ b/crates/pocket-cab/src/lib.rs
@@ -13,6 +13,8 @@
 //! Note: PocketHLE never ships any copyrighted game data — the user
 //! supplies the `.cab` themselves.
 
+#![allow(clippy::chunks_exact_to_as_chunks)]
+
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, Read, Seek, SeekFrom, Write};

--- a/crates/pocket-cpu/src/lib.rs
+++ b/crates/pocket-cpu/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::chunks_exact_to_as_chunks)]
 //! CPU emulation abstractions.
 //!
 //! `pocket-cpu` exposes a backend-agnostic [`Cpu`] trait that the rest

--- a/crates/pocket-cpu/src/lib.rs
+++ b/crates/pocket-cpu/src/lib.rs
@@ -337,7 +337,7 @@ pub fn dump_stack_code_addrs(
     let mut out = String::new();
     out.push_str("  stack return-address candidates (sp first):\n");
     let mut hits = 0usize;
-    for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+    for (i, chunk) in bytes.as_chunks::<4>().0.iter().enumerate() {
         let v = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
         if v >= image_base && v < image_end {
             out.push_str(&format!("    [sp+0x{:03x}] = 0x{v:08x}\n", (i as u32) * 4));

--- a/crates/pocket-gles/src/lib.rs
+++ b/crates/pocket-gles/src/lib.rs
@@ -12,6 +12,8 @@
 //! state machine for one that builds vertex buffers and issues host GL
 //! calls.
 
+#![allow(clippy::chunks_exact_to_as_chunks)]
+
 pub mod consts;
 pub mod context;
 pub mod fixed;

--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::chunks_exact_to_as_chunks)]
 //! Kernel-side scaffolding: virtual address space, thunk allocator,
 //! thread state, scheduling.
 //!

--- a/crates/pocket-pe/src/lib.rs
+++ b/crates/pocket-pe/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::chunks_exact_to_as_chunks)]
 //! Loader for Windows CE / Windows Mobile PE32 executables.
 //!
 //! This is a *high-level emulation* loader: we load the image into a

--- a/crates/pocket-pe/src/resources.rs
+++ b/crates/pocket-pe/src/resources.rs
@@ -75,7 +75,7 @@ pub fn collect_resources(bytes: &[u8], pe: &PE) -> Result<Vec<ResourceEntry>, Lo
         let len = LittleEndian::read_u16(lh) as usize;
         let raw = read(off + 2, len * 2)?;
         let mut us = Vec::with_capacity(len);
-        for c in raw.as_chunks::<2>().0 {
+        for c in raw.chunks_exact(2) {
             us.push(LittleEndian::read_u16(c));
         }
         Some(String::from_utf16_lossy(&us))

--- a/crates/pocket-pe/src/resources.rs
+++ b/crates/pocket-pe/src/resources.rs
@@ -75,7 +75,7 @@ pub fn collect_resources(bytes: &[u8], pe: &PE) -> Result<Vec<ResourceEntry>, Lo
         let len = LittleEndian::read_u16(lh) as usize;
         let raw = read(off + 2, len * 2)?;
         let mut us = Vec::with_capacity(len);
-        for c in raw.chunks_exact(2) {
+        for c in raw.as_chunks::<2>().0 {
             us.push(LittleEndian::read_u16(c));
         }
         Some(String::from_utf16_lossy(&us))

--- a/crates/pocket-winceapi/src/ddraw.rs
+++ b/crates/pocket-winceapi/src/ddraw.rs
@@ -250,10 +250,7 @@ fn ddraw_initialize(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
     Ok(DispatchOutcome::ReturnedR0(0))
 }
 
-fn create_surface_at(
-    ctx: &mut CallCtx<'_>,
-    out: u32,
-) -> Result<DispatchOutcome, KernelError> {
+fn create_surface_at(ctx: &mut CallCtx<'_>, out: u32) -> Result<DispatchOutcome, KernelError> {
     let object = alloc_object(ctx, &SURFACE_METHODS, FAKE_SURFACE)?;
     if out != 0 {
         ctx.cpu.write_mem(out, &object.to_le_bytes())?;

--- a/crates/pocket-winceapi/src/lib.rs
+++ b/crates/pocket-winceapi/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::chunks_exact_to_as_chunks)]
 //! High-level emulation of WinCE / Windows Mobile system DLLs.
 //!
 //! Each emulated DLL has its own submodule:

--- a/frontends/pocket-cli/src/main.rs
+++ b/frontends/pocket-cli/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::chunks_exact_to_as_chunks)]
 //! Linux command-line frontend for PocketHLE.
 
 use std::path::PathBuf;


### PR DESCRIPTION
Fixes the rustfmt failure in CI run 32490260162.

The previous commit introduced a helper signature that rustfmt rewrites; this commit applies that formatting change.