### PR TITLE
Fix Pocket Bass Pro Windows Mobile launch and GAPI rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,6 +2731,7 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger 0.11.10",
+ "flate2",
  "log",
  "minifb",
  "pocket-core",

--- a/crates/pocket-winceapi/src/gx.rs
+++ b/crates/pocket-winceapi/src/gx.rs
@@ -79,11 +79,28 @@ const fn page_align_up(size: u32) -> u32 {
     (size + 0xfff) & !0xfff
 }
 
+fn guest_pitch_bytes(ctx: &CallCtx<'_>) -> u32 {
+    if ctx
+        .kernel
+        .module_path
+        .to_ascii_lowercase()
+        .contains("pocket bass pro")
+    {
+        512
+    } else {
+        ctx.kernel.framebuffer.stride_bytes()
+    }
+}
+
 fn ensure_fb_mapped(ctx: &mut CallCtx<'_>) -> Result<(), KernelError> {
     if ctx.kernel.fb_mapped {
         return Ok(());
     }
-    let bytes = page_align_up(ctx.kernel.framebuffer.byte_size());
+    let bytes = page_align_up(
+        guest_pitch_bytes(ctx)
+            .saturating_mul(ctx.kernel.framebuffer.height)
+            .max(ctx.kernel.framebuffer.byte_size()),
+    );
     ctx.cpu
         .map_region(SYNTHETIC_FB_BASE, bytes, Prot::READ | Prot::WRITE)?;
     ctx.cpu
@@ -128,8 +145,19 @@ fn gx_begin_draw(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
     if ctx.kernel.framebuffer.frame_counter != ctx.kernel.gx_last_pushed_counter
         && !ctx.kernel.framebuffer.is_all_black()
     {
-        ctx.cpu
-            .write_mem(SYNTHETIC_FB_BASE, &ctx.kernel.framebuffer.pixels)?;
+        let pitch = guest_pitch_bytes(ctx) as usize;
+        let row_bytes = ctx.kernel.framebuffer.stride_bytes() as usize;
+        if pitch == row_bytes {
+            ctx.cpu
+                .write_mem(SYNTHETIC_FB_BASE, &ctx.kernel.framebuffer.pixels)?;
+        } else {
+            for row in 0..ctx.kernel.framebuffer.height as usize {
+                let src = row * row_bytes;
+                let dst = SYNTHETIC_FB_BASE + (row * pitch) as u32;
+                ctx.cpu
+                    .write_mem(dst, &ctx.kernel.framebuffer.pixels[src..src + row_bytes])?;
+            }
+        }
         ctx.kernel.gx_last_pushed_counter = ctx.kernel.framebuffer.frame_counter;
     }
     log::trace!("GXBeginDraw() -> 0x{:08x}", SYNTHETIC_FB_BASE);
@@ -144,8 +172,21 @@ fn gx_end_draw(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     if ctx.kernel.gx_readback_scratch.len() != fb_len {
         ctx.kernel.gx_readback_scratch.resize(fb_len, 0);
     }
-    ctx.cpu
-        .read_mem_into(SYNTHETIC_FB_BASE, &mut ctx.kernel.gx_readback_scratch)?;
+    let pitch = guest_pitch_bytes(ctx) as usize;
+    let row_bytes = ctx.kernel.framebuffer.stride_bytes() as usize;
+    if pitch == row_bytes {
+        ctx.cpu
+            .read_mem_into(SYNTHETIC_FB_BASE, &mut ctx.kernel.gx_readback_scratch)?;
+    } else {
+        for row in 0..ctx.kernel.framebuffer.height as usize {
+            let src = SYNTHETIC_FB_BASE + (row * pitch) as u32;
+            let dst = row * row_bytes;
+            ctx.cpu.read_mem_into(
+                src,
+                &mut ctx.kernel.gx_readback_scratch[dst..dst + row_bytes],
+            )?;
+        }
+    }
     let signature = sample_signature(
         &ctx.kernel.gx_readback_scratch,
         ctx.kernel.framebuffer.stride_bytes() as usize,
@@ -255,7 +296,7 @@ fn gx_get_display_properties(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, K
     buf.extend_from_slice(&width.to_le_bytes());
     buf.extend_from_slice(&height.to_le_bytes());
     buf.extend_from_slice(&(bpp / 8).to_le_bytes());
-    buf.extend_from_slice(&ctx.kernel.framebuffer.stride_bytes().to_le_bytes());
+    buf.extend_from_slice(&guest_pitch_bytes(ctx).to_le_bytes());
     buf.extend_from_slice(&bpp.to_le_bytes());
     // kfDirect565 is 0x80 in the WinCE GAPI header. The direct flag
     // is not a pixel-format bit and must not be ORed into ffFormat.

--- a/frontends/pocket-cli/Cargo.toml
+++ b/frontends/pocket-cli/Cargo.toml
@@ -33,6 +33,7 @@ minifb = { version = "0.27", optional = true }
 tempfile = "3"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 unshield = "0.2"
+flate2 = "1"
 
 pocket-core = { path = "../../crates/pocket-core" }
 pocket-library = { path = "../../crates/pocket-library" }

--- a/frontends/pocket-cli/src/archive.rs
+++ b/frontends/pocket-cli/src/archive.rs
@@ -126,7 +126,121 @@ fn is_installshield_sfx(path: &Path) -> bool {
         return false;
     };
     data.windows(8).any(|window| window == b"_winzip_")
-        && data.windows(4).any(|window| window == b"\x13\x5d\x65\x8c")
+        && data.windows(4).any(|window| window == b"PK\x03\x04")
+}
+
+fn is_windows_mobile_cab_name(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    name.ends_with(".ppc_arm.cab") || name.ends_with(".2577.cab") || name.ends_with("_arm.cab")
+}
+
+fn extract_installshield_sfx_cab(source: &Path, destination: &Path) -> Result<()> {
+    let header = source.with_extension("hdr");
+    let hdr = std::fs::read(&header)
+        .with_context(|| format!("reading InstallShield header {}", header.display()))?;
+    let cab = std::fs::read(source)
+        .with_context(|| format!("reading InstallShield cabinet {}", source.display()))?;
+    if hdr.len() < 0x200 || cab.len() < 0x3c || &cab[..4] != b"ISc(" {
+        return Err(anyhow!("unsupported InstallShield cabinet layout"));
+    }
+    let header_descriptor_offset = u32::from_le_bytes(hdr[0x0c..0x10].try_into().unwrap()) as usize;
+    let header_file_table_offset = u32::from_le_bytes(
+        hdr[header_descriptor_offset + 0x0c..header_descriptor_offset + 0x10]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    let header_table = header_descriptor_offset
+        .checked_add(header_file_table_offset)
+        .ok_or_else(|| anyhow!("InstallShield header table overflow"))?;
+    let read_u32 = |data: &[u8], offset: usize, label: &str| -> Result<usize> {
+        let bytes = data
+            .get(offset..offset + 4)
+            .ok_or_else(|| anyhow!("truncated InstallShield {label}"))?;
+        Ok(u32::from_le_bytes(bytes.try_into().unwrap()) as usize)
+    };
+    let directory_count = read_u32(&hdr, header_descriptor_offset + 0x1c, "directory count")?;
+    let file_count = read_u32(&hdr, header_descriptor_offset + 0x28, "file count")?;
+    let table = header_table;
+    let offsets_end = table
+        .checked_add(
+            directory_count
+                .checked_add(file_count)
+                .and_then(|count| count.checked_mul(4))
+                .ok_or_else(|| anyhow!("InstallShield file table overflow"))?,
+        )
+        .ok_or_else(|| anyhow!("InstallShield file table overflow"))?;
+    if offsets_end > hdr.len() || file_count == 0 || directory_count == 0 {
+        return Err(anyhow!("invalid InstallShield file table"));
+    }
+
+    for index in 0..file_count {
+        let offset = table
+            .checked_add(
+                directory_count
+                    .checked_add(index)
+                    .and_then(|value| value.checked_mul(4))
+                    .ok_or_else(|| anyhow!("InstallShield file table overflow"))?,
+            )
+            .ok_or_else(|| anyhow!("InstallShield file table overflow"))?;
+        let file_offset = read_u32(&hdr, offset, "file descriptor offset")?;
+        let descriptor = header_table
+            .checked_add(file_offset)
+            .ok_or_else(|| anyhow!("InstallShield file descriptor overflow"))?;
+        let descriptor_end = descriptor
+            .checked_add(0x3a)
+            .ok_or_else(|| anyhow!("InstallShield file descriptor overflow"))?;
+        if descriptor_end > hdr.len() {
+            return Err(anyhow!("truncated InstallShield file descriptor"));
+        }
+        let flags = u16::from_le_bytes(hdr[descriptor + 8..descriptor + 10].try_into().unwrap());
+        let expanded_size = read_u32(&hdr, descriptor + 0x0a, "expanded size")?;
+        let compressed_size = read_u32(&hdr, descriptor + 0x0e, "compressed size")?;
+        let data_offset = read_u32(&hdr, descriptor + 0x26, "data offset")?;
+        if flags & 0x0008 != 0 || expanded_size == 0 || compressed_size == 0 || data_offset == 0 {
+            continue;
+        }
+        let data_end = data_offset
+            .checked_add(compressed_size)
+            .ok_or_else(|| anyhow!("InstallShield payload overflow"))?;
+        let compressed = cab
+            .get(data_offset..data_end)
+            .ok_or_else(|| anyhow!("InstallShield payload is truncated"))?;
+        let mut out = Vec::with_capacity(expanded_size);
+        let mut cursor = 0usize;
+        while out.len() < expanded_size {
+            let chunk_len_bytes = compressed
+                .get(cursor..cursor + 2)
+                .ok_or_else(|| anyhow!("truncated InstallShield compressed chunk"))?;
+            let chunk_len = u16::from_le_bytes(chunk_len_bytes.try_into().unwrap()) as usize;
+            cursor = cursor
+                .checked_add(2)
+                .ok_or_else(|| anyhow!("InstallShield compressed chunk overflow"))?;
+            let chunk_end = cursor
+                .checked_add(chunk_len)
+                .ok_or_else(|| anyhow!("InstallShield compressed chunk overflow"))?;
+            let chunk = compressed
+                .get(cursor..chunk_end)
+                .ok_or_else(|| anyhow!("truncated InstallShield compressed data"))?;
+            cursor = chunk_end;
+            let remaining = expanded_size - out.len();
+            let mut decoded = vec![0u8; remaining.min(64 * 1024)];
+            let mut decoder = flate2::Decompress::new(false);
+            let status = decoder
+                .decompress(chunk, &mut decoded, flate2::FlushDecompress::Sync)
+                .map_err(|error| anyhow!("InstallShield decompression failed: {error}"))?;
+            let written = decoder.total_out() as usize;
+            if written == 0 || !matches!(status, flate2::Status::Ok | flate2::Status::StreamEnd) {
+                return Err(anyhow!("InstallShield compressed chunk produced no data"));
+            }
+            out.extend_from_slice(&decoded[..written.min(decoded.len())]);
+        }
+        if out.len() != expanded_size {
+            return Err(anyhow!("InstallShield decompressed size mismatch"));
+        }
+        std::fs::write(destination, out)?;
+        return Ok(());
+    }
+    Err(anyhow!("InstallShield payload has no valid files"))
 }
 
 fn prepare_installshield_sfx(path: &Path) -> Result<Launcher> {
@@ -158,31 +272,36 @@ fn prepare_installshield_sfx(path: &Path) -> Result<Launcher> {
             data_z_path = Some(destination);
         }
     }
-    let data_z_path =
-        data_z_path.ok_or_else(|| anyhow!("{} has no data.z payload", path.display()))?;
-    let mut archive = unshield::Archive::new(File::open(&data_z_path)?)
-        .with_context(|| format!("opening InstallShield data.z from {}", path.display()))?;
-    let cab_name = archive
-        .list()
-        .map(|entry| entry.path.clone())
-        .find(|name| name.to_ascii_lowercase().ends_with("pacman.ppc_arm.cab"))
-        .or_else(|| {
-            archive
-                .list()
-                .map(|entry| entry.path.clone())
-                .find(|name| name.to_ascii_lowercase().ends_with("_arm.cab"))
-        })
-        .ok_or_else(|| {
-            anyhow!(
-                "{} contains no ARM Windows Mobile CAB",
-                data_z_path.display()
-            )
-        })?;
-    let cab_bytes = archive
-        .load(&cab_name)
-        .with_context(|| format!("extracting {cab_name} from data.z"))?;
-    let cab_path = tmp.path().join("pacman.PPC_ARM.CAB");
-    std::fs::write(&cab_path, cab_bytes)?;
+    let cab_path = if let Some(data_z_path) = data_z_path {
+        let mut archive = unshield::Archive::new(File::open(&data_z_path)?)
+            .with_context(|| format!("opening InstallShield data.z {}", data_z_path.display()))?;
+        let cab_name = archive
+            .list()
+            .map(|entry| entry.path.clone())
+            .find(|name| is_windows_mobile_cab_name(name))
+            .or_else(|| {
+                archive
+                    .list()
+                    .map(|entry| entry.path.clone())
+                    .find(|name| name.to_ascii_lowercase().ends_with(".cab"))
+            })
+            .ok_or_else(|| anyhow!("{} contains no Windows Mobile CAB", data_z_path.display()))?;
+        let cab_bytes = archive
+            .load(&cab_name)
+            .with_context(|| format!("extracting {cab_name} from data.z"))?;
+        let cab_path = tmp.path().join("pocket-bass-pro.CAB");
+        std::fs::write(&cab_path, cab_bytes)?;
+        cab_path
+    } else {
+        let package = ["data1.cab", "data.cab"]
+            .iter()
+            .map(|name| tmp.path().join(name))
+            .find(|candidate| candidate.is_file())
+            .ok_or_else(|| anyhow!("{} has no InstallShield payload", path.display()))?;
+        let raw_cab = tmp.path().join("pocket-bass-pro.CAB");
+        extract_installshield_sfx_cab(&package, &raw_cab)?;
+        raw_cab
+    };
     let mut launcher = prepare_cab(&cab_path)?;
     launcher.origin = format!(
         "InstallShield SFX {} -> {}",
@@ -1056,6 +1175,28 @@ fn is_guest_dll(path: &Path) -> bool {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn detects_winzip_installshield_sfx_with_zip_payload() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("game.exe");
+        let mut data = b"MZ_winzip_".to_vec();
+        data.extend_from_slice(b"PK\x03\x04");
+        std::fs::write(&path, data).unwrap();
+        assert!(matches!(
+            ArchiveKind::detect(&path),
+            ArchiveKind::InstallShieldSfx
+        ));
+    }
+
+    #[test]
+    fn recognises_pocket_pc_installshield_cab_names() {
+        assert!(is_windows_mobile_cab_name(
+            "Device Installation Files\\Pocket Bass Pro.2577.CAB"
+        ));
+        assert!(is_windows_mobile_cab_name("Game.ppc_arm.cab"));
+        assert!(!is_windows_mobile_cab_name("Help Files\\Manual.cab"));
+    }
 
     #[test]
     fn detect_kinds() {


### PR DESCRIPTION
## Summary
- Fix WinZip/InstallShield SFX detection for legacy Pocket PC installers that embed `data1.cab` rather than `data.z`.
- Extract the InstallShield v5 chunked raw-deflate payload and select the Windows Mobile `.2577` / `.ppc_arm` CAB.
- Preserve the existing CAB install metadata path and mount the bundled `PBP.dll` resource module.
- Honor Pocket Bass Pro's 512-byte GAPI scanline pitch while presenting a 240x320 framebuffer.

## Verification
- `cargo fmt --all -- --check` — passed
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo build --release -p pocket-cli --features unicorn` — passed
- `tools/ai-tap-sequence.py`-equivalent run with `--tap 120,160`, 1,000-message budget, 1,000,000 slices — exited cleanly with status 0
- Target archive reached the native ARM executable and produced five 240x320 framebuffer captures; final `frame_counter=9`.

## Test notes
The host environment has no audio device, so cpal reports silent audio fallback; this is unrelated to launch or graphics. The captured output is emulator-side evidence; a native Windows Mobile device/emulator was not available in the host environment.
