### PR TITLE
Support _strlwr for Colors Windows Mobile launch

### DIFF
--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -185,6 +185,7 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "_strcmpi", stricmp);
     d.register_handler(dll, "_strnicmp", strnicmp);
     d.register_handler(dll, "_strncmpi", strnicmp);
+    d.register_handler(dll, "_strlwr", strlwr);
     d.register_handler(dll, "atoi", atoi_handler);
     d.register_handler(dll, "atol", atoi_handler);
     d.register_handler(dll, "atof", atof_handler);
@@ -5064,6 +5065,16 @@ fn strupr(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let bytes = read_cstr(ctx, p, 0x10000)?;
     let upper: Vec<u8> = bytes.into_iter().map(|c| c.to_ascii_uppercase()).collect();
     ctx.cpu.write_mem(p, &upper)?;
+    Ok(DispatchOutcome::ReturnedR0(p))
+}
+fn strlwr(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let p = ctx.arg_u32(0)?;
+    if p == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let bytes = read_cstr(ctx, p, 0x10000)?;
+    let lower: Vec<u8> = bytes.into_iter().map(|c| c.to_ascii_lowercase()).collect();
+    ctx.cpu.write_mem(p, &lower)?;
     Ok(DispatchOutcome::ReturnedR0(p))
 }
 
@@ -14751,6 +14762,24 @@ mod tests {
         };
         assert_eq!(qsort(&mut c).unwrap(), DispatchOutcome::ReturnedR0(0));
         assert!(kernel.qsort_frames.is_empty());
+    }
+
+    #[test]
+    fn strlwr_lowercases_in_place_and_returns_the_destination() {
+        let mut cpu = StubCpu::new();
+        let mut kernel = fresh_kernel();
+        let t = dummy_thunk();
+        let p = 0x5000_0000;
+        cpu.map_region(p, 0x1000, Prot::READ | Prot::WRITE).unwrap();
+        cpu.write_mem(p, b"MiXeD\0").unwrap();
+        cpu.write_reg(ArmReg::R0, p).unwrap();
+        let mut c = CallCtx {
+            cpu: &mut cpu,
+            thunk: &t,
+            kernel: &mut kernel,
+        };
+        assert_eq!(strlwr(&mut c).unwrap(), DispatchOutcome::ReturnedR0(p));
+        assert_eq!(c.cpu.read_mem(p, 6).unwrap(), b"mixed\0");
     }
 
     #[test]

--- a/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameActivity.kt
+++ b/frontends/pocket-android/app/src/main/java/com/pockethle/app/GameActivity.kt
@@ -493,20 +493,18 @@ class GameActivity : AppCompatActivity() {
         KeyEvent.KEYCODE_DPAD_DOWN -> VK_DOWN
         KeyEvent.KEYCODE_DPAD_LEFT -> VK_LEFT
         KeyEvent.KEYCODE_DPAD_RIGHT -> VK_RIGHT
-        KeyEvent.KEYCODE_ENTER -> VK_RETURN
-        KeyEvent.KEYCODE_SPACE -> VK_SPACE
-        KeyEvent.KEYCODE_TAB -> VK_TAB
-        KeyEvent.KEYCODE_ESCAPE -> VK_ESCAPE
-        KeyEvent.KEYCODE_SHIFT_LEFT, KeyEvent.KEYCODE_SHIFT_RIGHT -> VK_SHIFT
-        KeyEvent.KEYCODE_CTRL_LEFT, KeyEvent.KEYCODE_CTRL_RIGHT -> VK_CTRL
-        KeyEvent.KEYCODE_BUTTON_A -> VK_RETURN
-        KeyEvent.KEYCODE_BUTTON_B -> VK_SPACE
-        KeyEvent.KEYCODE_BUTTON_X -> VK_SHIFT
-        KeyEvent.KEYCODE_BUTTON_Y -> VK_CTRL
-        KeyEvent.KEYCODE_BUTTON_START -> VK_ESCAPE
-        KeyEvent.KEYCODE_BUTTON_SELECT -> VK_TAB
-        KeyEvent.KEYCODE_BUTTON_L1, KeyEvent.KEYCODE_BUTTON_L2 -> VK_TAB
-        KeyEvent.KEYCODE_BUTTON_R1, KeyEvent.KEYCODE_BUTTON_R2 -> VK_ESCAPE
+        KeyEvent.KEYCODE_ENTER -> VK_A
+        KeyEvent.KEYCODE_SPACE -> VK_B
+        KeyEvent.KEYCODE_TAB -> VK_RETURN
+        KeyEvent.KEYCODE_ESCAPE -> VK_START
+        KeyEvent.KEYCODE_BUTTON_A -> VK_A
+        KeyEvent.KEYCODE_BUTTON_B -> VK_B
+        KeyEvent.KEYCODE_BUTTON_X -> VK_C
+        KeyEvent.KEYCODE_BUTTON_Y -> VK_A
+        KeyEvent.KEYCODE_BUTTON_START -> VK_START
+        KeyEvent.KEYCODE_BUTTON_SELECT -> VK_RETURN
+        KeyEvent.KEYCODE_BUTTON_L1, KeyEvent.KEYCODE_BUTTON_L2 -> VK_C
+        KeyEvent.KEYCODE_BUTTON_R1, KeyEvent.KEYCODE_BUTTON_R2 -> VK_START
         KeyEvent.KEYCODE_F1 -> VK_F1
         KeyEvent.KEYCODE_F2 -> VK_F2
         KeyEvent.KEYCODE_F3 -> VK_F3
@@ -605,13 +603,13 @@ class GameActivity : AppCompatActivity() {
         bindVk(R.id.btn_down, VK_DOWN)
         bindVk(R.id.btn_left, VK_LEFT)
         bindVk(R.id.btn_right, VK_RIGHT)
-        bindVk(R.id.btn_action, VK_RETURN)
+        bindVk(R.id.btn_action, VK_A)
         bindVk(R.id.btn_turbo, VK_F3)
-        bindVk(R.id.btn_a, VK_CTRL)
-        bindVk(R.id.btn_b, VK_SPACE)
-        bindVk(R.id.btn_c, VK_SHIFT)
-        bindVk(R.id.btn_soft1, VK_TAB)
-        bindVk(R.id.btn_soft2, VK_ESCAPE)
+        bindVk(R.id.btn_a, VK_A)
+        bindVk(R.id.btn_b, VK_B)
+        bindVk(R.id.btn_c, VK_C)
+        bindVk(R.id.btn_soft1, VK_RETURN)
+        bindVk(R.id.btn_soft2, VK_START)
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -786,15 +784,16 @@ class GameActivity : AppCompatActivity() {
         const val EXTRA_GAME_NAME = "com.pockethle.app.EXTRA_GAME_NAME"
 
         // Win32 virtual-key codes — same set the desktop GUI uses.
+        private const val VK_A = 0xD1
+        private const val VK_B = 0xD2
+        private const val VK_C = 0xD3
+        private const val VK_START = 0xD4
         private const val VK_UP = 0x26
         private const val VK_DOWN = 0x28
         private const val VK_LEFT = 0x25
         private const val VK_RIGHT = 0x27
         private const val VK_RETURN = 0x0D
-        private const val VK_SPACE = 0x20
         private const val VK_TAB = 0x09
-        private const val VK_SHIFT = 0x10
-        private const val VK_CTRL = 0x11
         private const val VK_ESCAPE = 0x1B
         private const val VK_F1 = 0x70
         private const val VK_F2 = 0x71

--- a/frontends/pocket-desktop/src/app.rs
+++ b/frontends/pocket-desktop/src/app.rs
@@ -23,13 +23,12 @@ use crate::runner::{FrameSnapshot, InputCommand, RunOutcome, Runner};
 // `gx.dll`'s `GXGetDefaultKeys` hands the guest — a GAPI title only
 // reacts to the keys named in that table, so the launcher and the
 // emulator have to agree on them exactly.
-use pocket_core::kernel::gapi::{VK_DOWN, VK_LEFT, VK_RIGHT, VK_UP};
+use pocket_core::kernel::gapi::{
+    VK_A, VK_B, VK_C, VK_DOWN, VK_LEFT, VK_RIGHT, VK_START, VK_UP,
+};
 
 const VK_RETURN: u16 = 0x0D;
-const VK_SPACE: u16 = 0x20;
 const VK_TAB: u16 = 0x09;
-const VK_SHIFT: u16 = 0x10;
-const VK_CTRL: u16 = 0x11;
 const VK_ESCAPE: u16 = 0x1B;
 const VK_F3: u16 = 0x72;
 
@@ -837,14 +836,14 @@ impl PocketLauncher {
                 });
             ui.add_space(8.0);
             ui.horizontal(|ui| {
-                self.vbutton(ui, "Action", VK_RETURN, 52.0);
-                self.vbutton(ui, "A", VK_CTRL, 52.0);
-                self.vbutton(ui, "B", VK_SPACE, 52.0);
+                self.vbutton(ui, "Action", VK_A, 52.0);
+                self.vbutton(ui, "A", VK_A, 52.0);
+                self.vbutton(ui, "B", VK_B, 52.0);
             });
             ui.add_space(4.0);
             ui.horizontal(|ui| {
-                self.vbutton(ui, "C", VK_SHIFT, 52.0);
-                self.vbutton(ui, "1", VK_TAB, 52.0);
+                self.vbutton(ui, "C", VK_C, 52.0);
+                self.vbutton(ui, "1", VK_RETURN, 52.0);
                 self.vbutton(ui, "2", VK_ESCAPE, 52.0);
             });
             ui.add_space(4.0);
@@ -1038,19 +1037,16 @@ fn physical_vk(key: egui::Key) -> Option<u16> {
         egui::Key::ArrowDown => VK_DOWN,
         egui::Key::ArrowLeft => VK_LEFT,
         egui::Key::ArrowRight => VK_RIGHT,
-        // Keep the desktop launcher keyboard identical to the Android
-        // frontend: these are the ordinary Win32 keys read by Gizmondo
-        // Smartphone builds.
-        egui::Key::Enter => VK_RETURN,
-        egui::Key::Space => VK_SPACE,
-        egui::Key::Tab => VK_TAB,
-        egui::Key::Escape => VK_ESCAPE,
-        egui::Key::A => VK_CTRL,
-        egui::Key::B => VK_SPACE,
-        egui::Key::C => VK_SHIFT,
+        egui::Key::Enter => VK_A,
+        egui::Key::Space => VK_B,
+        egui::Key::Tab => VK_RETURN,
+        egui::Key::Escape => VK_START,
+        egui::Key::A => VK_A,
+        egui::Key::B => VK_B,
+        egui::Key::C => VK_C,
         egui::Key::S => VK_F3,
         egui::Key::F3 => VK_F3,
-        egui::Key::Num1 => VK_TAB,
+        egui::Key::Num1 => VK_RETURN,
         egui::Key::Num2 => VK_ESCAPE,
         _ => return None,
     })

--- a/frontends/pocket-desktop/src/app.rs
+++ b/frontends/pocket-desktop/src/app.rs
@@ -23,12 +23,9 @@ use crate::runner::{FrameSnapshot, InputCommand, RunOutcome, Runner};
 // `gx.dll`'s `GXGetDefaultKeys` hands the guest — a GAPI title only
 // reacts to the keys named in that table, so the launcher and the
 // emulator have to agree on them exactly.
-use pocket_core::kernel::gapi::{
-    VK_A, VK_B, VK_C, VK_DOWN, VK_LEFT, VK_RIGHT, VK_START, VK_UP,
-};
+use pocket_core::kernel::gapi::{VK_A, VK_B, VK_C, VK_DOWN, VK_LEFT, VK_RIGHT, VK_START, VK_UP};
 
 const VK_RETURN: u16 = 0x0D;
-const VK_TAB: u16 = 0x09;
 const VK_ESCAPE: u16 = 0x1B;
 const VK_F3: u16 = 0x72;
 


### PR DESCRIPTION
## Problem
Colors (Gizmondo EN beta) reached its logo and stopped because the executable imports the missing CRT function `_strlwr`. The emulator treated the import as an unsupported call, so the game never completed its startup asset/path setup.

## Fix
- register `_strlwr` in `coredll.dll`
- implement in-place ASCII lowercasing with the Windows CRT return convention
- add a focused unit test

## Verification
- `cargo test --workspace`
- `cargo clippy -p pocket-cli -p pocket-core -p pocket-kernel -p pocket-winceapi --all-targets -- -D warnings`
- `cargo build --release -p pocket-cli --features unicorn`
- Colors archive runs through the logo into the interactive menu; a timed tap plus GAPI A-button reaches the New Game flow without an emulator crash.