### PR TITLE
fix(gapi): preserve Pocket Bass Pro padded framebuffer pitch

### DIFF
--- a/crates/pocket-core/src/lib.rs
+++ b/crates/pocket-core/src/lib.rs
@@ -337,6 +337,7 @@ impl Emulator {
         // The GAPI mapping is sized from the framebuffer, so drop it;
         // the next GXOpenDisplay/GXBeginDraw re-maps at the new size.
         p.state.fb_mapped = false;
+        p.state.guest_fb_pitch = 0;
         p.state.gx_readback_scratch.clear();
     }
 }

--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -822,6 +822,8 @@ pub struct KernelState {
     /// requires `&mut dyn Cpu`, which isn't available outside a call,
     /// so we let the GAPI handlers do it.
     pub fb_mapped: bool,
+    /// Scanline pitch in the guest's raw framebuffer mapping. Zero means the canonical tightly packed stride.
+    pub guest_fb_pitch: u32,
     /// How many frames the guest has presented by writing the raw
     /// framebuffer with a `memcpy` we caught synchronously, rather
     /// than with the plain stores that only the polling read-back in
@@ -2059,6 +2061,7 @@ impl Process {
                 next_module_base: MODULE_REGION_BASE,
                 module_search_dirs,
                 fb_mapped: false,
+                guest_fb_pitch: 0,
                 direct_fb_frames: 0,
                 gx_readback_scratch: Vec::new(),
                 mem_op_scratch: Vec::new(),
@@ -2192,15 +2195,31 @@ fn sync_guest_framebuffer(cpu: &mut dyn Cpu, state: &mut KernelState) {
     if !state.fb_mapped || state.framebuffer.frame_counter != state.gx_last_pushed_counter {
         return;
     }
+    let pitch = state.guest_fb_pitch.max(state.framebuffer.stride_bytes()) as usize;
+    let row_bytes = state.framebuffer.stride_bytes() as usize;
     let len = state.framebuffer.pixels.len();
     if state.gx_readback_scratch.len() != len {
         state.gx_readback_scratch.resize(len, 0);
     }
-    if let Err(error) =
-        cpu.read_mem_into(SYNTHETIC_FRAMEBUFFER_BASE, &mut state.gx_readback_scratch)
-    {
-        log::warn!("unable to read the GAPI framebuffer: {error}");
-        return;
+    if pitch == row_bytes {
+        if let Err(error) =
+            cpu.read_mem_into(SYNTHETIC_FRAMEBUFFER_BASE, &mut state.gx_readback_scratch)
+        {
+            log::warn!("unable to read the GAPI framebuffer: {error}");
+            return;
+        }
+    } else {
+        for row in 0..state.framebuffer.height as usize {
+            let src = SYNTHETIC_FRAMEBUFFER_BASE + (row * pitch) as u32;
+            let dst = row * row_bytes;
+            if let Err(error) = cpu.read_mem_into(
+                src,
+                &mut state.gx_readback_scratch[dst..dst + row_bytes],
+            ) {
+                log::warn!("unable to read the GAPI framebuffer row: {error}");
+                return;
+            }
+        }
     }
     if state.gx_readback_scratch != state.framebuffer.pixels {
         state

--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -2212,10 +2212,9 @@ fn sync_guest_framebuffer(cpu: &mut dyn Cpu, state: &mut KernelState) {
         for row in 0..state.framebuffer.height as usize {
             let src = SYNTHETIC_FRAMEBUFFER_BASE + (row * pitch) as u32;
             let dst = row * row_bytes;
-            if let Err(error) = cpu.read_mem_into(
-                src,
-                &mut state.gx_readback_scratch[dst..dst + row_bytes],
-            ) {
+            if let Err(error) =
+                cpu.read_mem_into(src, &mut state.gx_readback_scratch[dst..dst + row_bytes])
+            {
                 log::warn!("unable to read the GAPI framebuffer row: {error}");
                 return;
             }

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -11049,7 +11049,10 @@ fn ext_escape(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
             raw[4..8].copy_from_slice(&pocket_kernel::SYNTHETIC_FRAMEBUFFER_BASE.to_le_bytes());
             raw[8..12].copy_from_slice(&(ctx.kernel.framebuffer.bpp / 8).to_le_bytes());
             raw[12..16].copy_from_slice(
-                &ctx.kernel.guest_fb_pitch.max(ctx.kernel.framebuffer.stride_bytes()).to_le_bytes(),
+                &ctx.kernel
+                    .guest_fb_pitch
+                    .max(ctx.kernel.framebuffer.stride_bytes())
+                    .to_le_bytes(),
             );
             raw[16..20].copy_from_slice(&ctx.kernel.framebuffer.width.to_le_bytes());
             raw[20..24].copy_from_slice(&ctx.kernel.framebuffer.height.to_le_bytes());
@@ -11061,7 +11064,10 @@ fn ext_escape(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
             info[0..4].copy_from_slice(&100u32.to_le_bytes());
             info[4..8].copy_from_slice(&pocket_kernel::SYNTHETIC_FRAMEBUFFER_BASE.to_le_bytes());
             info[8..12].copy_from_slice(
-                &ctx.kernel.guest_fb_pitch.max(ctx.kernel.framebuffer.stride_bytes()).to_le_bytes(),
+                &ctx.kernel
+                    .guest_fb_pitch
+                    .max(ctx.kernel.framebuffer.stride_bytes())
+                    .to_le_bytes(),
             );
             info[12..16].copy_from_slice(&ctx.kernel.framebuffer.width.to_le_bytes());
             info[16..20].copy_from_slice(&ctx.kernel.framebuffer.height.to_le_bytes());

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -14605,6 +14605,7 @@ mod tests {
             next_module_base: pocket_kernel::MODULE_REGION_BASE,
             module_search_dirs: Vec::new(),
             fb_mapped: false,
+            guest_fb_pitch: 0,
             direct_fb_frames: 0,
             gx_readback_scratch: Vec::new(),
             mem_op_scratch: Vec::new(),

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -11009,11 +11009,31 @@ fn ext_escape(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
         return Ok(DispatchOutcome::ReturnedR0(0));
     }
     if matches!(escape, GETRAWFRAMEBUFFER | GETGXINFO) && !ctx.kernel.fb_mapped {
-        let bytes = (ctx.kernel.framebuffer.byte_size() + 0xfff) & !0xfff;
+        let pitch = if ctx
+            .kernel
+            .module_path
+            .to_ascii_lowercase()
+            .contains("pocket bass pro")
+        {
+            512
+        } else {
+            ctx.kernel.framebuffer.stride_bytes()
+        };
+        ctx.kernel.guest_fb_pitch = pitch;
+        let bytes = (pitch
+            .saturating_mul(ctx.kernel.framebuffer.height)
+            .max(ctx.kernel.framebuffer.byte_size())
+            + 0xfff)
+            & !0xfff;
         ctx.cpu
             .map_region(SYNTHETIC_FRAMEBUFFER_BASE, bytes, Prot::READ | Prot::WRITE)?;
-        ctx.cpu
-            .write_mem(SYNTHETIC_FRAMEBUFFER_BASE, &ctx.kernel.framebuffer.pixels)?;
+        let row_bytes = ctx.kernel.framebuffer.stride_bytes() as usize;
+        for row in 0..ctx.kernel.framebuffer.height as usize {
+            let src = row * row_bytes;
+            let dst = SYNTHETIC_FRAMEBUFFER_BASE + (row * pitch as usize) as u32;
+            ctx.cpu
+                .write_mem(dst, &ctx.kernel.framebuffer.pixels[src..src + row_bytes])?;
+        }
         ctx.kernel.gx_last_pushed_counter = ctx.kernel.framebuffer.frame_counter;
         ctx.kernel.fb_mapped = true;
     }
@@ -11028,7 +11048,9 @@ fn ext_escape(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
             raw[2..4].copy_from_slice(&(ctx.kernel.framebuffer.bpp as u16).to_le_bytes());
             raw[4..8].copy_from_slice(&pocket_kernel::SYNTHETIC_FRAMEBUFFER_BASE.to_le_bytes());
             raw[8..12].copy_from_slice(&(ctx.kernel.framebuffer.bpp / 8).to_le_bytes());
-            raw[12..16].copy_from_slice(&ctx.kernel.framebuffer.stride_bytes().to_le_bytes());
+            raw[12..16].copy_from_slice(
+                &ctx.kernel.guest_fb_pitch.max(ctx.kernel.framebuffer.stride_bytes()).to_le_bytes(),
+            );
             raw[16..20].copy_from_slice(&ctx.kernel.framebuffer.width.to_le_bytes());
             raw[20..24].copy_from_slice(&ctx.kernel.framebuffer.height.to_le_bytes());
             ctx.cpu.write_mem(out_data, &raw)?;
@@ -11038,7 +11060,9 @@ fn ext_escape(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
             let mut info = [0u8; 0x84];
             info[0..4].copy_from_slice(&100u32.to_le_bytes());
             info[4..8].copy_from_slice(&pocket_kernel::SYNTHETIC_FRAMEBUFFER_BASE.to_le_bytes());
-            info[8..12].copy_from_slice(&ctx.kernel.framebuffer.stride_bytes().to_le_bytes());
+            info[8..12].copy_from_slice(
+                &ctx.kernel.guest_fb_pitch.max(ctx.kernel.framebuffer.stride_bytes()).to_le_bytes(),
+            );
             info[12..16].copy_from_slice(&ctx.kernel.framebuffer.width.to_le_bytes());
             info[16..20].copy_from_slice(&ctx.kernel.framebuffer.height.to_le_bytes());
             info[20..24].copy_from_slice(&ctx.kernel.framebuffer.bpp.to_le_bytes());

--- a/crates/pocket-winceapi/src/gx.rs
+++ b/crates/pocket-winceapi/src/gx.rs
@@ -354,6 +354,7 @@ pub(crate) mod tests {
             next_module_base: pocket_kernel::MODULE_REGION_BASE,
             module_search_dirs: Vec::new(),
             fb_mapped: false,
+            guest_fb_pitch: 0,
             direct_fb_frames: 0,
             gx_readback_scratch: Vec::new(),
             mem_op_scratch: Vec::new(),

--- a/crates/pocket-winceapi/src/gx.rs
+++ b/crates/pocket-winceapi/src/gx.rs
@@ -80,6 +80,15 @@ const fn page_align_up(size: u32) -> u32 {
 }
 
 fn guest_pitch_bytes(ctx: &CallCtx<'_>) -> u32 {
+    let native_pitch = ctx.kernel.framebuffer.stride_bytes();
+    if ctx.kernel.guest_fb_pitch == 0 {
+        native_pitch
+    } else {
+        ctx.kernel.guest_fb_pitch
+    }
+}
+
+fn initial_guest_pitch(ctx: &CallCtx<'_>) -> u32 {
     if ctx
         .kernel
         .module_path
@@ -96,15 +105,22 @@ fn ensure_fb_mapped(ctx: &mut CallCtx<'_>) -> Result<(), KernelError> {
     if ctx.kernel.fb_mapped {
         return Ok(());
     }
+    let pitch = initial_guest_pitch(ctx);
+    ctx.kernel.guest_fb_pitch = pitch;
     let bytes = page_align_up(
-        guest_pitch_bytes(ctx)
+        pitch
             .saturating_mul(ctx.kernel.framebuffer.height)
             .max(ctx.kernel.framebuffer.byte_size()),
     );
     ctx.cpu
         .map_region(SYNTHETIC_FB_BASE, bytes, Prot::READ | Prot::WRITE)?;
-    ctx.cpu
-        .write_mem(SYNTHETIC_FB_BASE, &ctx.kernel.framebuffer.pixels)?;
+    let row_bytes = ctx.kernel.framebuffer.stride_bytes() as usize;
+    for row in 0..ctx.kernel.framebuffer.height as usize {
+        let src = row * row_bytes;
+        let dst = SYNTHETIC_FB_BASE + (row * pitch as usize) as u32;
+        ctx.cpu
+            .write_mem(dst, &ctx.kernel.framebuffer.pixels[src..src + row_bytes])?;
+    }
     ctx.kernel.gx_last_pushed_counter = ctx.kernel.framebuffer.frame_counter;
     ctx.kernel.fb_mapped = true;
     Ok(())
@@ -168,12 +184,12 @@ fn gx_end_draw(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     if !ctx.kernel.fb_mapped {
         return Ok(DispatchOutcome::ReturnedR0(1));
     }
+    let pitch = guest_pitch_bytes(ctx) as usize;
+    let row_bytes = ctx.kernel.framebuffer.stride_bytes() as usize;
     let fb_len = ctx.kernel.framebuffer.pixels.len();
     if ctx.kernel.gx_readback_scratch.len() != fb_len {
         ctx.kernel.gx_readback_scratch.resize(fb_len, 0);
     }
-    let pitch = guest_pitch_bytes(ctx) as usize;
-    let row_bytes = ctx.kernel.framebuffer.stride_bytes() as usize;
     if pitch == row_bytes {
         ctx.cpu
             .read_mem_into(SYNTHETIC_FB_BASE, &mut ctx.kernel.gx_readback_scratch)?;


### PR DESCRIPTION
## Summary
- Preserve the guest framebuffer scanline pitch when Pocket Bass Pro discovers the display through `ExtEscape`.
- Use the same padded pitch for GAPI mapping, `GXBeginDraw`/`GXEndDraw`, and the run-loop readback path.
- Keep the existing 512-byte Pocket Bass Pro pitch while retaining the normal tightly packed stride for other games.

## Verification
- `git diff --check` — passed
- The uploaded archive was inspected and the available Pocket Bass Pro executable was confirmed to be x86/Intel 80386, not a runnable ARM Windows Mobile image.
- Rust tests/build could not be run in this environment because `cargo`/`rustc` are not installed.

This is the follow-up to the rendering fix that was previously implemented but not submitted separately.