### PR TITLE
Fix Snow Rally City Stage launch on Windows Mobile

### DIFF
--- a/crates/pocket-kernel/src/vfs.rs
+++ b/crates/pocket-kernel/src/vfs.rs
@@ -61,6 +61,11 @@ pub struct OpenFile {
     pub host_path: PathBuf,
     pub access: Access,
     pub file: File,
+    /// Whether the CRT stream was opened in text mode (`fopen` without
+    /// `b`). Only the stdio layer in `pocket-winceapi` consults this —
+    /// `CreateFileW` has no text mode on Windows CE, so handles opened
+    /// there are always binary.
+    pub text_mode: bool,
 }
 
 #[derive(Debug)]
@@ -665,6 +670,7 @@ impl Vfs {
                 host_path,
                 access,
                 file,
+                text_mode: false,
             },
         );
         Some(h)
@@ -734,6 +740,21 @@ impl Vfs {
         self.decoders.clear();
         self.registration.clear();
         n
+    }
+
+    /// Mark a handle as a CRT stream opened in text mode. The stdio
+    /// readers use this to apply CRLF -> LF translation the way the real
+    /// CRT does; see `crt_fgetws` in `pocket-winceapi`.
+    pub fn mark_text_mode(&mut self, handle: u32) {
+        if let Some(of) = self.handles.get_mut(&handle) {
+            of.text_mode = true;
+        }
+    }
+
+    /// Whether a handle was opened by `fopen`/`_wfopen` in text mode
+    /// (no `b` in the mode string). Non-stdio handles are binary.
+    pub fn is_text_mode(&self, handle: u32) -> bool {
+        self.handles.get(&handle).is_some_and(|of| of.text_mode)
     }
 
     pub fn is_open(&self, handle: u32) -> bool {

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -5692,12 +5692,7 @@ fn crt_fputc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     Ok(DispatchOutcome::ReturnedR0(c & 0xFF))
 }
 
-fn read_stdio_line(
-    ctx: &mut CallCtx<'_>,
-    h: u32,
-    max: usize,
-    text_mode: bool,
-) -> Vec<u8> {
+fn read_stdio_line(ctx: &mut CallCtx<'_>, h: u32, max: usize, text_mode: bool) -> Vec<u8> {
     let mut out = Vec::with_capacity(max);
     let mut byte = [0u8; 1];
     while out.len() + 1 < max {

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -5452,8 +5452,12 @@ fn open_cstr_path(ctx: &mut CallCtx<'_>, path: &str, mode: &str) -> u32 {
             }
         }
     }
+    let text_mode = !mode.contains('b');
     for cand in &candidates {
         if let Some(h) = ctx.kernel.vfs.open(cand, access, create) {
+            if text_mode {
+                ctx.kernel.vfs.mark_text_mode(h);
+            }
             log::trace!("fopen({cand:?}, {mode:?}) -> 0x{h:08x}");
             return h;
         }
@@ -5688,6 +5692,48 @@ fn crt_fputc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     Ok(DispatchOutcome::ReturnedR0(c & 0xFF))
 }
 
+fn read_stdio_line(
+    ctx: &mut CallCtx<'_>,
+    h: u32,
+    max: usize,
+    text_mode: bool,
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(max);
+    let mut byte = [0u8; 1];
+    while out.len() + 1 < max {
+        let read = ctx.kernel.vfs.read(h, &mut byte).unwrap_or(0);
+        if read == 0 {
+            break;
+        }
+        if text_mode && byte[0] == b'\r' {
+            let mut next = [0u8; 1];
+            let peeked = ctx.kernel.vfs.read(h, &mut next).unwrap_or(0);
+            if peeked == 0 {
+                out.push(b'\r');
+                break;
+            }
+            if next[0] == b'\n' {
+                out.push(b'\n');
+            } else {
+                out.push(b'\r');
+                out.push(next[0]);
+            }
+            if next[0] == b'\n' || out.len() + 1 >= max {
+                break;
+            }
+            continue;
+        }
+        out.push(byte[0]);
+        if byte[0] == b'\n' {
+            break;
+        }
+    }
+    if out.len() > max - 1 {
+        out.truncate(max - 1);
+    }
+    out
+}
+
 fn crt_fgets(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let buf = ctx.arg_u32(0)?;
     let n = ctx.arg_u32(1)?;
@@ -5695,18 +5741,8 @@ fn crt_fgets(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     if buf == 0 || n <= 1 || !ctx.kernel.vfs.is_open(h) {
         return Ok(DispatchOutcome::ReturnedR0(0));
     }
-    let mut out = Vec::with_capacity(n as usize);
-    let mut byte = [0u8; 1];
-    while out.len() + 1 < n as usize {
-        let read = ctx.kernel.vfs.read(h, &mut byte).unwrap_or(0);
-        if read == 0 {
-            break;
-        }
-        out.push(byte[0]);
-        if byte[0] == b'\n' {
-            break;
-        }
-    }
+    let text_mode = ctx.kernel.vfs.is_text_mode(h);
+    let mut out = read_stdio_line(ctx, h, n as usize, text_mode);
     if out.is_empty() {
         return Ok(DispatchOutcome::ReturnedR0(0));
     }
@@ -5722,18 +5758,8 @@ fn crt_fgetws(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     if buf == 0 || n <= 1 || !ctx.kernel.vfs.is_open(h) {
         return Ok(DispatchOutcome::ReturnedR0(0));
     }
-    let mut out = Vec::with_capacity(n as usize);
-    let mut byte = [0u8; 1];
-    while out.len() + 1 < n as usize {
-        let read = ctx.kernel.vfs.read(h, &mut byte).unwrap_or(0);
-        if read == 0 {
-            break;
-        }
-        out.push(byte[0]);
-        if byte[0] == b'\n' {
-            break;
-        }
-    }
+    let text_mode = ctx.kernel.vfs.is_text_mode(h);
+    let mut out = read_stdio_line(ctx, h, n as usize, text_mode);
     if out.is_empty() {
         return Ok(DispatchOutcome::ReturnedR0(0));
     }


### PR DESCRIPTION
## Summary
- preserve CRT text-vs-binary mode for VFS-backed streams
- translate CRLF to LF in `fgets` and `fgetws`, matching Windows Mobile text-mode CRT behavior
- fixes Snow Rally City Stage properties parsing so `CS.cover.jpg` and other resources resolve without a trailing carriage return

## Validation
- `cargo build --release -p pocket-cli --features unicorn`
- `cargo test -p pocket-winceapi --lib` — 99 passed
- `cargo test -p pocket-kernel --lib` — 89 passed
- `python3 tools/ai-tap-sequence.py ../game/SnowRallyCityStage_Full.ARM.CAB --cpu unicorn --dump-frames-to ../runs/snow-final-frames --max-frames 4 --message-budget 1 --max-slices 300000` — exit 0; CAB recognized, ARM PE loaded, all install mounts configured, no missing `CS.cover.jpg`; no frame was emitted before the bounded run ended

## Notes
- audio output is silent in this headless environment because no ALSA output device is available; this is reported by the emulator and is unrelated to the launch fix.