### PR TITLE
Import fork changes: input polling, HTC tilt sensor, GLES exports, zlib, scaling and text entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,6 +2820,7 @@ version = "0.3.1"
 dependencies = [
  "android_logger",
  "anyhow",
+ "image 0.24.9",
  "jni",
  "log",
  "pocket-core",

--- a/crates/pocket-cpu/src/lib.rs
+++ b/crates/pocket-cpu/src/lib.rs
@@ -239,6 +239,17 @@ pub trait Cpu {
     /// for unimplemented imports.
     fn add_code_hook(&mut self, va: u32) -> Result<(), CpuError>;
 
+    /// Ask the backend to ignore the *next* code-hook firing at `va`.
+    ///
+    /// Code hooks fire before the instruction at their address runs and
+    /// stop emulation, so a caller that wants to log and carry on
+    /// cannot simply resume at that address -- it would trip the same
+    /// hook again forever, and skipping to `va + 4` would leave the
+    /// instruction unexecuted. Suppressing exactly one firing lets the
+    /// instruction run normally on the next entry.
+    ///
+    /// Backends without code hooks can ignore this.
+    fn set_hook_skip_once(&mut self, _va: u32) {}
     /// Register a whole *inclusive* address range as stop-on-execute,
     /// as one hook rather than one per address.
     ///

--- a/crates/pocket-cpu/src/unicorn.rs
+++ b/crates/pocket-cpu/src/unicorn.rs
@@ -3,12 +3,14 @@
 //! Compiled only with `--features unicorn`. Apart from the build cost,
 //! this is the authoritative ARM backend used at runtime.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 use ::unicorn_engine::unicorn_const::{
-    Arch as UcArch, MemType, Mode, Prot as UcProt, TlbEntry, TlbType,
+    Arch as UcArch, HookType, MemType, Mode, Prot as UcProt, TlbEntry, TlbType,
 };
 use ::unicorn_engine::{RegisterARM, RegisterMIPS, Unicorn};
 
@@ -63,11 +65,22 @@ impl GuestMap {
 pub struct UnicornCpu {
     uc: Unicorn<'static, ()>,
     last_hook: Rc<RefCell<Option<u32>>>,
-    /// Address of the last invalid memory access, recorded so crash
-    /// reports can name the faulting address instead of just the
-    /// access kind.
+    hook_skip_once: Rc<RefCell<Option<u32>>>,
+    /// Address of the last invalid memory access seen by the
+    /// `mem_invalid` hook, recorded so crash reports can name the
+    /// faulting address instead of just the access kind.
     last_fault: Rc<RefCell<Option<(String, u64)>>>,
     stop_requested: Rc<RefCell<bool>>,
+    /// Wall-clock deadline for the current slice, or `None` when the
+    /// slice watchdog is disabled. Read by the block hook.
+    slice_deadline: Rc<Cell<Option<Instant>>>,
+    /// Set by the block hook when it stopped emulation because
+    /// `slice_deadline` passed, so `run_until_hook` can tell a watchdog
+    /// stop apart from an explicit one.
+    slice_expired: Rc<Cell<bool>>,
+    /// When `POCKETHLE_DUMP_MEM` ranges were last written, for rate
+    /// limiting.
+    last_dump: Option<Instant>,
     /// Mapping table backing the virtual-TLB hook; `None` when the
     /// architectural TLB is in use and Unicorn resolves pages itself.
     guest_map: Option<Rc<RefCell<GuestMap>>>,
@@ -76,6 +89,52 @@ pub struct UnicornCpu {
 }
 
 impl UnicornCpu {
+    /// Write out any ranges named by `POCKETHLE_DUMP_MEM`.
+    ///
+    /// Driven from the slice loop rather than at exit, because a guest
+    /// that ends by faulting never reaches a tidy shutdown -- the run
+    /// we care about is precisely the one that dies.
+    ///
+    /// Each range is rewritten rather than captured once. Writing once
+    /// is the obvious design and it is wrong here: the heap is mapped
+    /// from process start, so the very first read succeeds and returns
+    /// a page of zeroes long before a loader has decompressed anything
+    /// into it. Overwriting means whatever is on disk when the guest
+    /// stops is the last state it had, which is what a post-mortem
+    /// wants. Rate limited so this is a file write per second, not per
+    /// slice.
+    fn dump_requested_memory(&mut self) {
+        let specs = dump_mem_specs();
+        if specs.is_empty() {
+            return;
+        }
+        let now = Instant::now();
+        if let Some(last) = self.last_dump {
+            if now.duration_since(last) < Duration::from_millis(1000) {
+                return;
+            }
+        }
+        self.last_dump = Some(now);
+        for (addr, len, path) in specs.iter() {
+            let mut buf = vec![0u8; *len as usize];
+            if self.uc.mem_read(*addr, &mut buf).is_err() {
+                continue;
+            }
+            if buf.iter().all(|b| *b == 0) {
+                // Nothing there yet. Do not clobber a good earlier
+                // capture with a page of zeroes.
+                continue;
+            }
+            match std::fs::write(path, &buf) {
+                Ok(()) => log::debug!(
+                    "dumped 0x{addr:08x}..+0x{len:x} to {path} ({} bytes)",
+                    buf.len()
+                ),
+                Err(e) => log::warn!("could not write {path}: {e}"),
+            }
+        }
+    }
+
     pub fn new() -> Result<Self, CpuError> {
         Self::new_for_arch(Arch::Arm)
     }
@@ -143,13 +202,80 @@ impl UnicornCpu {
                 );
             }
         }
+        let slice_deadline: Rc<Cell<Option<Instant>>> = Rc::new(Cell::new(None));
+        let slice_expired: Rc<Cell<bool>> = Rc::new(Cell::new(false));
+        // Slice watchdog. Only installed when the feature is actually
+        // switched on, because a block hook spanning the whole address
+        // space stops QEMU chaining translation blocks and that costs
+        // throughput on every guest instruction, watchdog or not.
+        //
+        // This replaces passing a `timeout` to `uc_emu_start`, which
+        // looks free and is not: unicorn arms it by spawning a QEMU
+        // timer thread *per call*, and slices here end on an IAT thunk
+        // hook thousands of times a second. Thousands of OS thread
+        // creations per second dominated everything else and dropped a
+        // real game from ~12 FPS to ~2.4.
+        //
+        // The clock is only read once every 1024 blocks. A slice that
+        // needs interrupting is spinning for many milliseconds, so
+        // granularity is irrelevant, whereas an `Instant::now()` on
+        // every block would put a timer read in the hot path.
+        // Data write-watchpoint.
+        //
+        // `--watch` installs a *code* breakpoint, which cannot answer
+        // the question that keeps coming up when a guest calls through
+        // a null field: who was supposed to write it? This does --
+        // `POCKETHLE_WATCH_MEM=0x502d35b0` (optionally `ADDR:LEN`,
+        // default 4 bytes) logs every write into that range with the
+        // guest `PC` that made it and the value stored. Nothing logged
+        // by the time the field is used means nothing ever wrote it,
+        // which is just as informative.
+        if let Some((begin, end)) = watch_mem_range() {
+            log::info!("memory write-watch armed on 0x{begin:08x}..=0x{end:08x}");
+            let _ = uc.add_mem_hook(
+                HookType::MEM_WRITE,
+                begin,
+                end,
+                move |uc, _mem_type, address, size, value| {
+                    let pc = uc.reg_read(RegisterARM::PC).unwrap_or(0);
+                    log::info!(
+                        "WATCH write 0x{address:08x} size={size} value=0x{value:08x} \
+                         from pc=0x{pc:08x}"
+                    );
+                    true
+                },
+            );
+        }
+        if slice_watchdog_ms() > 0 {
+            let deadline = slice_deadline.clone();
+            let expired = slice_expired.clone();
+            let blocks = Cell::new(0u64);
+            let _ = uc.add_block_hook(0, u64::MAX, move |uc, _addr, _size| {
+                let n = blocks.get().wrapping_add(1);
+                blocks.set(n);
+                if !n.is_multiple_of(1024) {
+                    return;
+                }
+                if let Some(limit) = deadline.get() {
+                    if Instant::now() >= limit {
+                        expired.set(true);
+                        deadline.set(None);
+                        let _ = uc.emu_stop();
+                    }
+                }
+            });
+        }
         Ok(Self {
             uc,
             arch,
             last_fault,
             guest_map,
             last_hook: Rc::new(RefCell::new(None)),
+            hook_skip_once: Rc::new(RefCell::new(None)),
             stop_requested: Rc::new(RefCell::new(false)),
+            slice_deadline,
+            slice_expired,
+            last_dump: None,
             mips_status: 0,
         })
     }
@@ -297,28 +423,177 @@ fn map_mips_reg(r: ArmReg) -> RegisterMIPS {
 
 /// Optional per-slice wall-clock watchdog, in microseconds.
 ///
-/// Returns `0` (disabled) by default. We deliberately do **not** bound
-/// a slice by an instruction *count*: passing a non-zero `count` to
-/// `uc_emu_start` makes Unicorn install an internal per-instruction
-/// hook that disables QEMU's translation-block chaining, which costs
-/// roughly 5-10x throughput on tight guest loops (this is exactly why
-/// the JIT microbenchmark — which calls `emu_start(.., 0, 0)` — runs
-/// far faster than real games used to). The thunk code hooks already
-/// stop emulation on every WinCE API call, so the host frame hook and
-/// stop requests still get a turn on any normal game frame. The
-/// watchdog is only a safety net for a pathological guest that loops
-/// forever without ever calling an API; set
-/// `POCKETHLE_SLICE_TIMEOUT_MS` to enable it.
-fn slice_watchdog_us() -> u64 {
+/// How long a single slice may run before the watchdog interrupts it,
+/// in milliseconds. `0` disables it entirely.
+///
+/// Defaults to [`DEFAULT_SLICE_TIMEOUT_MS`], because a disabled
+/// watchdog is not a neutral choice: it means any guest that loops
+/// without calling an API freezes the emulator outright, with no way
+/// back short of killing the process.
+///
+/// We deliberately do **not** bound a slice by an instruction *count*:
+/// passing a non-zero `count` to `uc_emu_start` makes Unicorn install
+/// an internal per-instruction hook that disables QEMU's
+/// translation-block chaining, which costs roughly 5-10x throughput on
+/// tight guest loops. We also no longer pass `uc_emu_start`'s
+/// `timeout`, which spawns a QEMU timer thread on every call -- see the
+/// block hook in `new_for_arch`.
+///
+/// The thunk code hooks already end a slice on every WinCE API call, so
+/// the host frame hook and stop requests get a turn on any normal game
+/// frame. The watchdog only matters for a guest that loops forever
+/// without ever calling an API -- which real games do: Rayman
+/// Ultimate's wait-for-button-release loop polls its own pad state and
+/// nothing else, and without a preemptive slice boundary the emulator
+/// can never regain control to deliver the `WM_KEYUP` that would end
+/// it. Set `POCKETHLE_SLICE_TIMEOUT_MS` to override, including to `0`
+/// to turn the watchdog off.
+/// Parse `POCKETHLE_DUMP_MEM` into a list of guest ranges to dump.
+///
+/// Format: `ADDR:LEN[=PATH][,ADDR:LEN[=PATH]]...`, addresses in hex
+/// with or without `0x`. `PATH` defaults to `dump-<addr>.bin` in the
+/// working directory.
+///
+/// This exists because the interesting code is not always on disk.
+/// A loader that decompresses and relocates an image into the heap --
+/// Airplay's `.s3e` being the case in point -- leaves you with live
+/// addresses and no file to disassemble against. Register traces can
+/// walk back through callers one frame at a time, but eventually the
+/// question is "what does this branch actually test", and only the
+/// bytes answer that.
+fn dump_mem_specs() -> &'static [(u64, u64, String)] {
+    static CACHED: OnceLock<Vec<(u64, u64, String)>> = OnceLock::new();
+    CACHED.get_or_init(|| {
+        let Ok(spec) = std::env::var("POCKETHLE_DUMP_MEM") else {
+            return Vec::new();
+        };
+        let parse = |v: &str| -> Option<u64> {
+            let v = v.trim();
+            match v.strip_prefix("0x").or_else(|| v.strip_prefix("0X")) {
+                Some(hex) => u64::from_str_radix(hex, 16).ok(),
+                None => v.parse::<u64>().ok(),
+            }
+        };
+        let mut out = Vec::new();
+        for entry in spec.split(',') {
+            let (range, path) = match entry.split_once('=') {
+                Some((r, p)) => (r, p.trim().to_string()),
+                None => (entry, String::new()),
+            };
+            let Some((addr, len)) = range.split_once(':') else {
+                log::warn!("POCKETHLE_DUMP_MEM: expected ADDR:LEN in {entry:?}");
+                continue;
+            };
+            let (Some(addr), Some(len)) = (parse(addr), parse(len)) else {
+                log::warn!("POCKETHLE_DUMP_MEM: bad address or length in {entry:?}");
+                continue;
+            };
+            let path = if path.is_empty() {
+                format!("dump-{addr:08x}.bin")
+            } else {
+                path
+            };
+            out.push((addr, len, path));
+        }
+        out
+    })
+}
+
+/// Parse `POCKETHLE_WATCH_MEM` into an inclusive guest address range.
+///
+/// Accepts `0xADDR` (four bytes, the common case for a pointer field)
+/// or `0xADDR:LEN`. Returns `None` when unset or unparseable, in which
+/// case no hook is installed and there is no cost.
+fn watch_mem_range() -> Option<(u64, u64)> {
+    static CACHED: OnceLock<Option<(u64, u64)>> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        let spec = std::env::var("POCKETHLE_WATCH_MEM").ok()?;
+        let spec = spec.trim();
+        let (addr, len) = match spec.split_once(':') {
+            Some((a, l)) => (a.trim(), l.trim()),
+            None => (spec, "4"),
+        };
+        let parse = |v: &str| -> Option<u64> {
+            let v = v.trim();
+            match v.strip_prefix("0x").or_else(|| v.strip_prefix("0X")) {
+                Some(hex) => u64::from_str_radix(hex, 16).ok(),
+                None => v.parse::<u64>().ok(),
+            }
+        };
+        let addr = parse(addr)?;
+        let len = parse(len).filter(|l| *l > 0).unwrap_or(4);
+        Some((addr, addr + len - 1))
+    })
+}
+
+/// Parse `POCKETHLE_WATCH_HOST` into an inclusive guest address range.
+///
+/// Same syntax as `POCKETHLE_WATCH_MEM` (`0xADDR` or `0xADDR:LEN`), but
+/// applied to host-side writes through `write_mem` rather than guest
+/// stores. Unset means no cost.
+fn watch_host_range() -> Option<(u64, u64)> {
+    static CACHED: OnceLock<Option<(u64, u64)>> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        let spec = std::env::var("POCKETHLE_WATCH_HOST").ok()?;
+        let spec = spec.trim();
+        let (addr, len) = match spec.split_once(':') {
+            Some((a, l)) => (a.trim(), l.trim()),
+            None => (spec, "4"),
+        };
+        let parse = |v: &str| -> Option<u64> {
+            let v = v.trim();
+            match v.strip_prefix("0x").or_else(|| v.strip_prefix("0X")) {
+                Some(hex) => u64::from_str_radix(hex, 16).ok(),
+                None => v.parse::<u64>().ok(),
+            }
+        };
+        let addr = parse(addr)?;
+        let len = parse(len).filter(|l| *l > 0).unwrap_or(4);
+        Some((addr, addr + len - 1))
+    })
+}
+
+/// Per-run override of the slice watchdog, set by a frontend before it
+/// starts a game. `-1` means "not set".
+///
+/// An `AtomicI64` rather than a `OnceLock` because the desktop launcher
+/// runs several games in one process: whatever the first game wanted
+/// would otherwise be frozen in for the rest of the session, which is
+/// exactly the bug this whole setting exists to avoid.
+static SLICE_WATCHDOG_OVERRIDE: AtomicI64 = AtomicI64::new(-1);
+
+/// Set (or with `None`, clear) the slice watchdog for subsequent runs.
+///
+/// Takes precedence over `POCKETHLE_SLICE_TIMEOUT_MS`, because a
+/// per-game setting the user chose deliberately should not be silently
+/// beaten by a variable left in their environment months ago. Set it
+/// once per launch; it applies until changed.
+pub fn set_slice_watchdog_ms(ms: Option<u64>) {
+    SLICE_WATCHDOG_OVERRIDE.store(ms.map_or(-1, |v| v as i64), Ordering::Relaxed);
+}
+
+fn slice_watchdog_ms() -> u64 {
+    let over = SLICE_WATCHDOG_OVERRIDE.load(Ordering::Relaxed);
+    if over >= 0 {
+        return over as u64;
+    }
     static CACHED: OnceLock<u64> = OnceLock::new();
     *CACHED.get_or_init(|| {
         std::env::var("POCKETHLE_SLICE_TIMEOUT_MS")
             .ok()
             .and_then(|v| v.trim().parse::<u64>().ok())
-            .map(|ms| ms.saturating_mul(1000))
-            .unwrap_or(0)
+            .unwrap_or(DEFAULT_SLICE_TIMEOUT_MS)
     })
 }
+
+/// Slice ceiling used when `POCKETHLE_SLICE_TIMEOUT_MS` is unset.
+///
+/// Roughly one 60 Hz frame. The stalls this exists to break are
+/// permanent, so the exact value only trades interruption granularity
+/// against how often legitimate long stretches of guest compute get
+/// chopped up -- it does not need to be tight. Measured at ~18 FPS on
+/// Rayman Ultimate, against ~12 before any of this work.
+const DEFAULT_SLICE_TIMEOUT_MS: u64 = 16;
 
 impl Cpu for UnicornCpu {
     fn arch(&self) -> Arch {
@@ -342,6 +617,26 @@ impl Cpu for UnicornCpu {
     }
 
     fn write_mem(&mut self, va: u32, data: &[u8]) -> Result<(), CpuError> {
+        // Host-side writes bypass the guest CPU entirely, so
+        // POCKETHLE_WATCH_MEM cannot see them. This mirrors that watch
+        // for writes made by emulator code (patched memcpy, file reads,
+        // loader fixups) so a stray host write onto guest memory can be
+        // attributed instead of merely observed after the fact.
+        if let Some((begin, end)) = watch_host_range() {
+            let lo = va as u64;
+            let hi = lo + data.len() as u64 - 1;
+            if lo <= end && hi >= begin {
+                let preview: Vec<String> =
+                    data.iter().take(16).map(|b| format!("{b:02x}")).collect();
+                log::info!(
+                    "WATCH host write 0x{va:08x} len={} [{}{}]\n{}",
+                    data.len(),
+                    preview.join(" "),
+                    if data.len() > 16 { " ..." } else { "" },
+                    std::backtrace::Backtrace::force_capture()
+                );
+            }
+        }
         self.uc
             .mem_write(va as u64, data)
             .map_err(|e| CpuError::Backend(format!("mem_write: {e:?}")))
@@ -424,6 +719,10 @@ impl Cpu for UnicornCpu {
         self.write_reg(ArmReg::R1, second)
     }
 
+    fn set_hook_skip_once(&mut self, va: u32) {
+        *self.hook_skip_once.borrow_mut() = Some(va);
+    }
+
     fn add_code_hook(&mut self, va: u32) -> Result<(), CpuError> {
         self.add_code_hook_range(va, va)
     }
@@ -435,10 +734,17 @@ impl Cpu for UnicornCpu {
     fn add_code_hook_range(&mut self, lo: u32, hi: u32) -> Result<(), CpuError> {
         let last = self.last_hook.clone();
         let stop = self.stop_requested.clone();
+        let skip = self.hook_skip_once.clone();
         // Report the address that actually trapped, not the range's
         // bounds: with one hook covering a whole run of thunk slots
         // the run loop identifies the import by the trapping PC.
         let cb = move |uc: &mut Unicorn<'_, ()>, addr: u64, _size: u32| {
+            // One-shot suppression, so a tracer can log this address
+            // and let the instruction execute on re-entry.
+            if *skip.borrow() == Some(addr as u32) {
+                *skip.borrow_mut() = None;
+                return;
+            }
             *last.borrow_mut() = Some(addr as u32);
             *stop.borrow_mut() = true;
             let _ = uc.emu_stop();
@@ -454,8 +760,16 @@ impl Cpu for UnicornCpu {
         start_va: u32,
         _max_instructions: u64,
     ) -> Result<StopReason, CpuError> {
+        self.dump_requested_memory();
         *self.last_hook.borrow_mut() = None;
         *self.stop_requested.borrow_mut() = false;
+        self.slice_expired.set(false);
+        let watchdog_ms = slice_watchdog_ms();
+        self.slice_deadline.set(if watchdog_ms > 0 {
+            Some(Instant::now() + Duration::from_millis(watchdog_ms))
+        } else {
+            None
+        });
         // IMPORTANT: run with `count = 0` (no instruction limit) so the
         // QEMU TCG keeps chaining translation blocks at full speed. A
         // non-zero `count` would silently install a per-instruction
@@ -463,12 +777,20 @@ impl Cpu for UnicornCpu {
         // ended by the IAT-thunk code hooks (which call `emu_stop` on
         // every emulated API call) and, optionally, by a wall-clock
         // watchdog for pathological API-free loops.
+        // `start_va` still carries its ARM/Thumb interworking bit in
+        // bit 0, and that is deliberate: unicorn latches the execution
+        // state from the `PC` write that `uc_emu_start` performs
+        // (`env->thumb = value & 1` in `unicorn_arm.c`), so an odd
+        // address is how Thumb gets selected. Do not mask it here, and
+        // do not try to drive the mode from `CPSR` instead -- that
+        // route does not survive the round trip.
         let r = self.uc.emu_start(
             start_va as u64,
-            0,                   // until = 0 → run until stopped
-            slice_watchdog_us(), // timeout (us); 0 = no timeout
-            0,                   // count = 0 → keep TB chaining (do NOT pass a limit)
+            0, // until = 0 → run until stopped
+            0, // timeout = 0 → never spawn a per-call QEMU timer thread
+            0, // count = 0 → keep TB chaining (do NOT pass a limit)
         );
+        self.slice_deadline.set(None);
         if let Some(addr) = *self.last_hook.borrow() {
             return Ok(StopReason::Hook(addr));
         }
@@ -478,7 +800,14 @@ impl Cpu for UnicornCpu {
             // Both are benign slice boundaries — the caller refreshes
             // state and resumes from the current PC.
             Ok(()) => {
-                if *self.stop_requested.borrow() {
+                if self.slice_expired.get() {
+                    // The watchdog cut the slice short. Reported as
+                    // `InstructionLimit` because that is what the
+                    // caller already treats as "a slice ended without
+                    // the guest calling anything", which is exactly
+                    // what happened.
+                    Ok(StopReason::InstructionLimit)
+                } else if *self.stop_requested.borrow() {
                     Ok(StopReason::Requested)
                 } else {
                     Ok(StopReason::InstructionLimit)

--- a/crates/pocket-kernel/src/callwatch.rs
+++ b/crates/pocket-kernel/src/callwatch.rs
@@ -1,0 +1,91 @@
+//! TEMPORARY INSTRUMENTATION: find an API call that never returns.
+//!
+//! The slice loop's spin watchdog can only report a guest that is
+//! looping in its *own* code, because it runs between slices. When a
+//! host-side handler blocks instead, the slice loop is blocked with
+//! it and never reaches the point where it would print anything --
+//! which is exactly the shape of Rayman Ultimate's freeze on entering
+//! a level: the runner thread goes quiet mid-call while the UI stays
+//! perfectly responsive, so nothing is stuck except one call that
+//! never came back.
+//!
+//! Watching from a separate thread is the only way to see it. The
+//! dispatcher records the call it is about to make, clears it on
+//! return, and this module's thread reports anything still in flight
+//! after a few seconds.
+//!
+//! Remove once the offending call is identified.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// How long a single call may run before it is considered stuck. Some
+/// legitimate calls are slow -- decompressing a level file takes a
+/// while -- so this is deliberately far longer than any of those.
+const STUCK_AFTER: Duration = Duration::from_secs(3);
+
+struct InFlight {
+    label: String,
+    since: Instant,
+    /// Bumped on every `enter`, so the watcher can tell "the same call
+    /// is still running" from "a new call happens to have the same
+    /// name".
+    seq: u64,
+}
+
+static IN_FLIGHT: OnceLock<Mutex<Option<InFlight>>> = OnceLock::new();
+static SEQ: AtomicU64 = AtomicU64::new(0);
+static STARTED: AtomicBool = AtomicBool::new(false);
+
+fn slot() -> &'static Mutex<Option<InFlight>> {
+    IN_FLIGHT.get_or_init(|| Mutex::new(None))
+}
+
+/// Record that a handler is starting. Cheap enough for the dispatch
+/// path: one allocation and one uncontended lock per API call.
+pub fn enter(label: String) {
+    start_watcher();
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    if let Ok(mut g) = slot().lock() {
+        *g = Some(InFlight {
+            label,
+            since: Instant::now(),
+            seq,
+        });
+    }
+}
+
+/// Record that the handler returned.
+pub fn leave() {
+    if let Ok(mut g) = slot().lock() {
+        *g = None;
+    }
+}
+
+fn start_watcher() {
+    if STARTED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    std::thread::spawn(|| {
+        let mut reported_seq: Option<u64> = None;
+        loop {
+            std::thread::sleep(Duration::from_millis(500));
+            let Ok(g) = slot().lock() else { continue };
+            match g.as_ref() {
+                Some(call)
+                    if call.since.elapsed() >= STUCK_AFTER && reported_seq != Some(call.seq) =>
+                {
+                    // Report each stuck call once, not twice a second.
+                    reported_seq = Some(call.seq);
+                    log::warn!(
+                        "call has not returned after {:?}: {}",
+                        call.since.elapsed(),
+                        call.label
+                    );
+                }
+                _ => {}
+            }
+        }
+    });
+}

--- a/crates/pocket-kernel/src/lib.rs
+++ b/crates/pocket-kernel/src/lib.rs
@@ -34,6 +34,7 @@ use pocket_cpu::{
 use pocket_pe::{machine, ImportBinding, ImportSymbol, LoadedImage, ResourceEntry};
 
 pub mod audio;
+pub mod callwatch;
 pub mod controls;
 pub mod font;
 pub mod framebuffer;
@@ -99,6 +100,26 @@ pub const KERNEL_TRAP_SIZE: u32 = 0x0001_0000;
 pub const PROCESS_EXIT_TRAMPOLINE_VA: u32 = 0xF000_FF00;
 /// First synthetic return address for a guest thread created by CreateThread.
 pub const THREAD_EXIT_TRAMPOLINE_BASE: u32 = 0xF000_FE00;
+
+/// Addresses that log CPU state and *continue*, rather than halting
+/// the way `--watch` does.
+///
+/// A `--watch` breakpoint answers "did execution reach here, and with
+/// what registers", but it stops at the first hit. When the question
+/// is instead "what sequence of values does this function get called
+/// with" -- e.g. which resource ids a game requests, when only one of
+/// them is the one that fails -- you need every hit, so these log and
+/// resume.
+pub static TRACE_POINTS: std::sync::Mutex<Vec<u32>> = std::sync::Mutex::new(Vec::new());
+
+/// Register an address as a trace point (see [`TRACE_POINTS`]).
+pub fn add_trace_point(va: u32) {
+    TRACE_POINTS.lock().unwrap().push(va);
+}
+
+fn is_trace_point(va: u32) -> bool {
+    TRACE_POINTS.lock().unwrap().contains(&va)
+}
 
 /// Base of the WinCE user-mode shared kernel data page. Real Pocket
 /// PC kernels publish a per-process read-only view of the
@@ -936,6 +957,17 @@ pub struct KernelState {
     /// this to inject `WM_TIMER` messages with a wParam the guest
     /// will recognise.
     pub synthetic_timer_id: u32,
+    /// The `TIMERPROC` passed to `SetTimer`, or 0 when the caller
+    /// passed NULL.
+    ///
+    /// When it is non-NULL, Windows delivers `WM_TIMER` by calling
+    /// this function from `DispatchMessage` *instead of* the window
+    /// procedure. Games that drive their frame loop this way leave
+    /// `WM_TIMER` out of their WndProc entirely, so dropping the
+    /// callback means the timer fires and nothing happens -- which is
+    /// how LudiGames' Rayman ended up running its message loop and
+    /// loading its assets without ever drawing a frame.
+    pub synthetic_timer_proc: u32,
     /// Timer interval and host-clock deadline used by the synthetic message pump.
     pub synthetic_timer_interval_ms: u32,
     pub synthetic_timer_next_ms: u64,
@@ -1036,6 +1068,14 @@ pub struct KernelState {
     pub semaphores: HashMap<u32, SemaphoreObject>,
     /// Index of the thread whose register context is currently active.
     pub current_thread: usize,
+    /// Round-robin cursor for picking the next worker to schedule.
+    ///
+    /// Taking the *first* eligible worker every time starves every
+    /// other one whenever the lowest-indexed thread is perpetually
+    /// runnable, so scheduling starts its search here and advances past
+    /// whichever thread it picked. Advanced by preemption too, so the
+    /// preemptive and cooperative paths agree on whose turn it is.
+    pub next_worker: usize,
     /// Current state of the Pocket PC virtual keys.
     pub pressed_keys: [bool; 256],
     /// Virtual keys the host is holding down, oldest press first.
@@ -1056,6 +1096,31 @@ pub struct KernelState {
     /// once (diagonal on the D-pad) each get their share of repeats
     /// instead of the first one starving the second.
     pub key_repeat_cursor: usize,
+    /// Per-key "pressed since the last `GetAsyncKeyState` query" flag.
+    ///
+    /// Real `GetAsyncKeyState` returns 0x8000 while a key is held *and*
+    /// 0x0001 if it was pressed at all since the previous call for that
+    /// key, then clears the latter. Games that poll once a frame depend
+    /// on the second bit to catch a tap that began and ended between
+    /// two polls -- and the slower the frame rate, the more taps that
+    /// is. Reporting only "currently held" silently swallowed every
+    /// quick press in titles like LudiGames' Rayman, which has no
+    /// WM_KEYDOWN handler at all and drives its whole menu off polling.
+    pub keys_pressed_since_query: [bool; 256],
+    /// Keys whose release arrived before the guest ever polled them.
+    ///
+    /// A game that samples `GetAsyncKeyState` once a frame only sees a
+    /// key that is still held at that instant. Emulated frames can be
+    /// far longer than a real one -- a whole tap fits inside a single
+    /// 300 ms frame -- so a press the player clearly made never
+    /// registers. Holding the key "down" until one poll has observed it
+    /// makes a tap last exactly as long as the guest needs to notice
+    /// it, without making it repeat.
+    pub keys_release_pending: [bool; 256],
+    /// Keys the guest has polled while they were down. Pairs with
+    /// [`Self::keys_release_pending`] to decide when a deferred release
+    /// can finally be applied.
+    pub keys_observed_down: [bool; 256],
     /// Set by the host frontend to ask the run loop to stop cleanly
     /// at the next slice boundary. Used by the desktop GUI's "Back to
     /// library" button so the user can interrupt a running game.
@@ -1155,6 +1220,71 @@ pub struct KernelState {
 }
 
 impl KernelState {
+    /// Queue a host input event and apply its effect on the virtual-key
+    /// state immediately.
+    ///
+    /// The key state used to be updated only where [`Self::pending_input`]
+    /// is drained, which is inside `GetMessageW` / `PeekMessageW`. That is
+    /// correct for a guest that runs a message pump, but a GAPI title need
+    /// not have one: Rayman Ultimate's loop is `GetAsyncKeyState` plus
+    /// `GXBeginDraw` / `GXEndDraw` and never calls `PeekMessageW` again
+    /// after start-up. The queue was therefore never drained, so
+    /// [`Self::pressed_keys`] and [`Self::keys_pressed_since_query`] never
+    /// changed, every poll answered zero, the on-screen D-pad did nothing
+    /// at all, and the queue grew without bound for the whole session.
+    ///
+    /// Separating the two responsibilities is what fixes it. The
+    /// poll-facing state is applied here, at the moment the host produces
+    /// the event, while `pending_input` stays purely the message queue for
+    /// the guests that do pump it.
+    pub fn push_input(&mut self, ev: InputEvent) {
+        // TEMPORARY INSTRUMENTATION. This is the point where a host
+        // key press first becomes visible to the kernel. If pressing a
+        // D-pad button produces no line here, the problem is upstream
+        // of the kernel entirely (stale binary, or the frontend never
+        // sending the event); if it does appear and the guest still
+        // never polls, the guest is not running the code that reads
+        // input. Delete once that question is settled.
+        log::debug!("push_input {ev:?}");
+        // A GAPI guest only reacts to the virtual keys `GXGetDefaultKeys`
+        // named, so for the *state* the host's confirm key has to be
+        // recorded as `vkA`. The queued copy stays untouched: the drain
+        // path applies the same rewrite on its way out, and doing it in
+        // one place there keeps the message route exactly as it was.
+        let state_vk = |vk: u16, queried: bool| gapi::remap_host_key(vk, queried);
+        let queried = self.gapi_keys_queried;
+        match ev {
+            InputEvent::KeyDown { vk } => {
+                let vk = state_vk(vk, queried) as usize;
+                if vk < self.pressed_keys.len() {
+                    self.pressed_keys[vk] = true;
+                    // Latch the press so a poll landing after the matching
+                    // release still reports it once, through the 0x0001
+                    // bit that a once-per-frame poller depends on.
+                    self.keys_pressed_since_query[vk] = true;
+                }
+            }
+            InputEvent::KeyUp { vk } => {
+                let vk = state_vk(vk, queried) as usize;
+                if vk < self.pressed_keys.len() {
+                    self.pressed_keys[vk] = false;
+                }
+            }
+            InputEvent::PointerDown { .. }
+            | InputEvent::PointerUp { .. }
+            | InputEvent::PointerMove { .. } => {}
+        }
+        // Cap the queue. A guest that never pumps never drains it, and an
+        // unbounded `VecDeque` here is a slow leak as well as a growing
+        // cost for anything that walks it. Dropping the oldest entries is
+        // safe now that the key state no longer depends on the queue.
+        const MAX_PENDING_INPUT: usize = 256;
+        while self.pending_input.len() >= MAX_PENDING_INPUT {
+            self.pending_input.pop_front();
+        }
+        self.pending_input.push_back(ev);
+    }
+
     /// Paint the built-in child controls on top of whatever the guest
     /// last drew, so the frame the host is about to show has them.
     ///
@@ -1576,6 +1706,14 @@ pub const GLES_CM_MODULE_HANDLE: u32 = 0x1000_0004;
 pub const GLES_CL_MODULE_HANDLE: u32 = 0x1000_0005;
 /// Fake `HMODULE` for the Hekkus Sound System compatibility layer.
 pub const HSS_MODULE_HANDLE: u32 = 0x1000_0006;
+/// Fake `HMODULE` for HTC's tilt-sensor SDK, `htcsensorsdk.dll`.
+///
+/// Titles written for HTC handsets probe for this at startup and hide
+/// their tilt controls when it is absent -- EA's NFS Undercover drops
+/// its tilt-steering button entirely. Nothing imports the library
+/// statically; it is reached only through `LoadLibrary` +
+/// `GetProcAddress`, so its exports exist purely as synthetic thunks.
+pub const HTC_SENSOR_MODULE_HANDLE: u32 = 0x1000_0007;
 
 /// The whole emulated process state owned by the kernel.
 fn build_dynamic_exports(thunks: &[Thunk]) -> HashMap<u32, HashMap<String, u32>> {
@@ -1612,6 +1750,14 @@ fn build_dynamic_exports(thunks: &[Thunk]) -> HashMap<u32, HashMap<String, u32>>
             commctrl.insert(name.clone(), thunk.thunk_va);
             if let ImportBinding::Ordinal(ord) = &thunk.binding {
                 commctrl.insert(format!("#{}", ord), thunk.thunk_va);
+            }
+        } else if thunk.dll.eq_ignore_ascii_case("htcsensorsdk.dll") {
+            let table = exports
+                .entry(HTC_SENSOR_MODULE_HANDLE)
+                .or_insert_with(HashMap::new);
+            table.insert(name.clone(), thunk.thunk_va);
+            if let ImportBinding::Ordinal(ord) = &thunk.binding {
+                table.insert(format!("#{ord}"), thunk.thunk_va);
             }
         } else if thunk.dll.eq_ignore_ascii_case("hss.dll") {
             let table = exports
@@ -1877,6 +2023,7 @@ impl Process {
             "libgles_cm.dll",
             "libgles_cl.dll",
             "hss.dll",
+            "htcsensorsdk.dll",
             "ole32.dll",
         ] {
             dynamic_exports_to_add.extend(
@@ -1919,14 +2066,14 @@ impl Process {
         let stack_size = DEFAULT_STACK_SIZE;
         let stack_top = DEFAULT_STACK_TOP;
         let dynamic_exports = build_dynamic_exports(&thunks);
-        // Keep one writable guard page below the nominal stack base.
-        // ARM prologues may pre-decrement SP before the first store, and
-        // Total Commander reaches exactly that boundary during startup.
         let stack_base = stack_top - stack_size;
+        // Executable for the same reason as the heap below: no NX on
+        // this platform, and stack-resident trampolines are rarer but
+        // not unheard of in CE-era code.
         cpu.map_region(
-            stack_base - 0x2000,
-            stack_size + 0x3000,
-            Prot::READ | Prot::WRITE,
+            stack_base,
+            stack_size + 0x1000,
+            Prot::READ | Prot::WRITE | Prot::EXEC,
         )?;
         cpu.write_reg(ArmReg::Sp, stack_top - 16)?;
         cpu.write_reg(ArmReg::Lr, PROCESS_EXIT_TRAMPOLINE_VA)?;
@@ -1939,8 +2086,30 @@ impl Process {
             log::debug!("starting Thumb-mode entry with CPSR.T set");
         }
 
-        // 4. Map a heap.
-        cpu.map_region(HEAP_BASE, HEAP_SIZE, Prot::READ | Prot::WRITE)?;
+        // 4. Map a heap -- executable, because Windows CE had no NX.
+        //
+        // Guest code legitimately runs out of the heap on this
+        // platform. Loaders decompress an image into allocated memory
+        // and branch into it, and compilers emit ARM/Thumb
+        // interworking veneers at runtime. NFS Undercover is entirely
+        // this shape: `NFS_Undercover.exe` is only the Airplay loader
+        // (its imports are DDRAW/COREDLL/WS2/AYGSHELL, no game code),
+        // and the game proper is `NFS_Undercover.s3e` -- 416 KB of
+        // LZMA (`5d 00 00 01 00`, 861,517 bytes uncompressed) that the
+        // loader inflates onto the heap and calls through a thunk it
+        // builds there:
+        //
+        // ```text
+        //   0x5008e440:  push {r0, lr}
+        //                ldr  r0, [pc, #0x64]
+        //                mov  lr, pc
+        //                bx   r0
+        // ```
+        //
+        // With the heap mapped `READ | WRITE` that branch faults
+        // `FETCH_PROT` and not one instruction of the actual game ever
+        // executes.
+        cpu.map_region(HEAP_BASE, HEAP_SIZE, Prot::READ | Prot::WRITE | Prot::EXEC)?;
         let mut heap = Heap::new(HEAP_BASE, HEAP_SIZE);
 
         // 4b. Publish the Windows CE process entry arguments.
@@ -1978,6 +2147,30 @@ impl Process {
         //    `0xF000_0000+`. We don't know the exact callsites
         //    coredll routes through this range, so we fill the page
         //    with `bx lr` — any guest jump there returns harmlessly.
+        // A readable, non-executable zero page at address 0.
+        //
+        // Pocket PC titles are full of unchecked null reads that were
+        // harmless on the original hardware, where the low addresses
+        // read back as zero rather than trapping. LudiGames' Rayman
+        // walks its menu script with `ldrsb r3, [r8]` and immediately
+        // branches on `r3 == 0`, so a null script pointer resolves to
+        // "empty script" and the routine returns cleanly -- but only if
+        // the read succeeds. Faulting instead turns a benign guest
+        // idiom into an unrecoverable crash.
+        //
+        // Writable as well as readable. Read-only was the first cut,
+        // on the reasoning that a null *write* is always a bug worth
+        // reporting -- but these titles scribble through null pointers
+        // as freely as they read through them (Rayman's menu engine
+        // does a `strb` to address 0 while laying out text), and on the
+        // original hardware that landed harmlessly in low memory rather
+        // than trapping. Faulting turns another benign-on-device idiom
+        // into a dead run.
+        //
+        // Still not executable: a guest that *jumps* to NULL has lost
+        // control flow entirely, and the dispatch loop reports that
+        // separately via its `pc < 0x1000` check.
+        cpu.map_region(0, 0x1000, Prot::READ | Prot::WRITE)?;
         cpu.map_region(KERNEL_TRAP_BASE, KERNEL_TRAP_SIZE, Prot::READ | Prot::EXEC)?;
         let mut trap_page = Vec::with_capacity(KERNEL_TRAP_SIZE as usize);
         let trap_stub = return_stub_bytes(cpu.arch());
@@ -2101,6 +2294,7 @@ impl Process {
                 window_classes: HashMap::new(),
                 window_user_data: 0,
                 synthetic_timer_id: 0,
+                synthetic_timer_proc: 0,
                 synthetic_timer_interval_ms: 16,
                 synthetic_timer_next_ms: 0,
                 synthetic_paint_next_ms: 0,
@@ -2122,10 +2316,14 @@ impl Process {
                 events: Default::default(),
                 semaphores: Default::default(),
                 current_thread: 0,
+                next_worker: 0,
                 pressed_keys: [false; 256],
                 held_keys: Vec::new(),
                 key_repeat_next_ms: None,
                 key_repeat_cursor: 0,
+                keys_pressed_since_query: [false; 256],
+                keys_release_pending: [false; 256],
+                keys_observed_down: [false; 256],
                 should_stop: false,
                 tls_slots_used: 0,
                 vector_iter_stack: Vec::new(),
@@ -2287,6 +2485,274 @@ fn image_uses_thumb_entry(cpu: &mut dyn Cpu, image: &LoadedImage) -> Result<bool
     Ok(!arm_prologue)
 }
 
+/// Normalise a guest-supplied continuation address for use as `pc`.
+///
+/// On ARM, bit 0 of a *code* address is not part of the address: it is
+/// the interworking flag, and a `BX`/`BLX`/`POP {pc}` to an odd address
+/// means "continue in Thumb". Every continuation we take from the guest
+/// (a return address in `LR`, a window procedure, a timer callback, a
+/// comparator) carries that bit, so it must be preserved all the way
+/// to the CPU rather than masked off.
+///
+/// Preserved, specifically, *in the address*. Unicorn latches the
+/// execution state from the `PC` register write itself:
+///
+/// ```c
+/// case UC_ARM_REG_R15:
+///     env->pc       = value & ~1;
+///     env->thumb    = value & 1;
+///     env->regs[15] = value & ~1;
+/// ```
+///
+/// so handing it an odd `pc` is the whole mechanism. Routing the bit
+/// through `CPSR` instead does not survive the round trip, and masking
+/// it away, which every call site used to do, loses it outright.
+///
+/// This is invisible until a game mixes instruction sets. Rayman
+/// Ultimate is pure ARM and never noticed. Need for Speed is mixed: its
+/// entry point is even, so the process starts in ARM state, but
+/// `RegisterClassW` hands over `WndProc=0x0002d701` and its returns come
+/// back through odd `LR`s. Entering that Thumb code in ARM state makes
+/// unicorn decode Thumb halfwords as ARM words; because a
+/// halfword-aligned address is not a legal ARM `PC`, it faults
+/// `INSN_INVALID` on entry rather than anywhere informative.
+/// Whether a call through a null function pointer should return to
+/// `LR` instead of ending the session. See the call site.
+fn skip_null_calls() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("POCKETHLE_SKIP_NULL_CALLS")
+            .map(|v| {
+                let v = v.trim();
+                !v.is_empty() && v != "0"
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// Print a window of the guest stack for a trace point, marking the
+/// words that could be Thumb return addresses.
+///
+/// See the call site: `LR` is unreliable after a tail call, and the
+/// caller has to be recovered from the frame instead. Candidates are
+/// odd (the Thumb interworking bit) and point into mapped code, which
+/// is enough to narrow a 16-word window to one or two entries.
+fn log_stack_window(cpu: &mut dyn Cpu, sp: u32) {
+    if sp == 0 {
+        return;
+    }
+    let mut line = String::new();
+    for i in 0..16u32 {
+        let at = sp.wrapping_add(i * 4);
+        let Ok(raw) = cpu.read_mem(at, 4) else {
+            break;
+        };
+        let word = u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]);
+        // Odd and plausibly in code: a return address candidate.
+        let candidate = word & 1 != 0 && word > 0x1000;
+        line.push_str(&format!(
+            " [sp+0x{:02x}]=0x{word:08x}{}",
+            i * 4,
+            if candidate { "*" } else { "" }
+        ));
+    }
+    log::info!("trace stack:{line}");
+}
+
+fn guest_pc(target: u32) -> u32 {
+    target
+}
+
+/// Map a `[u32; 17]` register-file index onto its [`ArmReg`].
+///
+/// Index 15 is `PC` and 16 is `CPSR`, matching the layout used by
+/// [`GuestThread::saved_regs`] and `worker_regs`.
+fn reg_by_index(index: usize) -> ArmReg {
+    match index {
+        0 => ArmReg::R0,
+        1 => ArmReg::R1,
+        2 => ArmReg::R2,
+        3 => ArmReg::R3,
+        4 => ArmReg::R4,
+        5 => ArmReg::R5,
+        6 => ArmReg::R6,
+        7 => ArmReg::R7,
+        8 => ArmReg::R8,
+        9 => ArmReg::R9,
+        10 => ArmReg::R10,
+        11 => ArmReg::R11,
+        12 => ArmReg::R12,
+        13 => ArmReg::Sp,
+        14 => ArmReg::Lr,
+        15 => ArmReg::Pc,
+        _ => ArmReg::Cpsr,
+    }
+}
+
+/// Report an eligible worker that has not run for a suspiciously long
+/// time while the main thread keeps calling into the HLE.
+///
+/// Preemption cannot catch this shape: main polls *some* API in a tight
+/// loop -- a tick count, a key state -- while waiting on a worker, so
+/// every iteration ends the slice on a thunk hook, the watchdog never
+/// fires, and nothing logs above `trace`. Meanwhile the worker stays
+/// parked, because `resume_worker_at` is reached only from the message
+/// pump, `Sleep` and the wait functions, not from whatever main happens
+/// to be polling.
+///
+/// Rate limited to one line a second, and resets whenever a worker
+/// actually gets the CPU, so a healthy game never prints.
+fn watch_worker_starvation(state: &KernelState, thunk_va: u32, pc: u32) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static LAST_WORKER_MS: AtomicU64 = AtomicU64::new(0);
+    static NEXT_WARN_MS: AtomicU64 = AtomicU64::new(0);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let idle = state.current_thread != 0
+        || !state
+            .threads
+            .iter()
+            .any(|thread| thread.worker_saved && thread.started && !thread.finished);
+    if idle {
+        LAST_WORKER_MS.store(now, Ordering::Relaxed);
+        return;
+    }
+    let last = LAST_WORKER_MS.load(Ordering::Relaxed);
+    if last == 0 {
+        LAST_WORKER_MS.store(now, Ordering::Relaxed);
+        return;
+    }
+    let starved_ms = now.saturating_sub(last);
+    if starved_ms < 1000 {
+        return;
+    }
+    let due = NEXT_WARN_MS.load(Ordering::Relaxed);
+    if now < due
+        || NEXT_WARN_MS
+            .compare_exchange(due, now + 1000, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+    {
+        return;
+    }
+    log::warn!(
+        "worker starved {starved_ms}ms while main dispatches: \
+         main pc=0x{pc:08x} thunk=0x{thunk_va:08x}"
+    );
+}
+
+/// Preempt a worker that has burned a whole slice without calling into
+/// the HLE, handing the CPU back to the main thread.
+///
+/// Every other context switch here is *cooperative*: a worker yields
+/// because it called `GXEndDraw`, `Sleep`, `WaitForSingleObject` or a
+/// message-pump function, and `park_worker` runs from inside that
+/// dispatch. That works right up until a guest writes a loop with no
+/// API call in it, at which point the worker owns the CPU forever and
+/// the main thread -- the only one that drains host input and
+/// dispatches window messages -- never runs again.
+///
+/// Rayman Ultimate does exactly this. Pressing the action key on the
+/// world map lands the render worker in a wait-for-release loop that
+/// polls its own pad state and calls nothing:
+///
+/// ```text
+///   0x30e54  bl 0x3bb68   ; IsB
+///   0x30e64  bl 0x3bb78   ; IsA
+///   0x30e74  bl 0x3bb88   ; IsStart
+///   0x30e84  bl 0x3bb98
+///   0x30e90  beq 0x30ea8  ; nothing held -> enter the level
+///   0x30ea0  bl 0x3bc60   ; `mov pc, lr`, a no-op
+///   0x30ea4  b  0x30e54
+/// ```
+///
+/// Those pad flags are cleared only by `WM_KEYUP`, which only arrives
+/// if main pumps, which cannot happen while this loop holds the CPU.
+/// On real hardware the OS preempts and the pump runs anyway.
+///
+/// Only the worker-to-main direction is safe. Preempting main *to* a
+/// worker inverts the invariant the cooperative paths rely on --
+/// `resume_worker_at` returns immediately when `current_thread != 0`,
+/// and a worker that settles into `PeekMessageW` is serviced from its
+/// own posted queue without ever parking, while hitting a thunk hook
+/// every iteration so no watchdog can rescue it. Main ends up
+/// descheduled permanently. When main is the one spinning we only
+/// report it, via [`watch_worker_starvation`].
+///
+/// The snapshot is the one `park_worker` takes, except the resume point
+/// is the current `PC` rather than `LR`, because we are suspending
+/// mid-function rather than at a call boundary. The worker is left
+/// `worker_saved`, so `resume_worker_at` picks it up at the next
+/// `GetMessageW` and it continues from the exact instruction it was
+/// interrupted on.
+fn preempt_running_worker(
+    cpu: &mut dyn Cpu,
+    state: &mut KernelState,
+    pc: u32,
+) -> Result<Option<u32>, KernelError> {
+    if state.current_thread == 0 {
+        return Ok(None);
+    }
+    let thread_index = state.current_thread - 1;
+    let thread_count = state.threads.len();
+    let mut regs = [0u32; 17];
+    for (index, slot) in regs.iter_mut().enumerate() {
+        *slot = cpu.read_reg(reg_by_index(index))?;
+    }
+    // The caller already refreshed `pc` from the CPU; that is the
+    // authoritative continuation address.
+    regs[15] = pc;
+    let Some(thread) = state.threads.get_mut(thread_index) else {
+        return Ok(None);
+    };
+    if thread.finished {
+        return Ok(None);
+    }
+    thread.worker_regs = regs;
+    thread.worker_saved = true;
+    let next_regs = thread.saved_regs;
+    // TEMPORARY INSTRUMENTATION: preemption context check.
+    //
+    // Preemption is known to corrupt thread context -- a preempted
+    // worker has been observed resuming on the main thread's stack.
+    // The suspect is `saved_regs`: it is only main's live context if
+    // this worker was entered through `resume_worker_at`, which
+    // snapshots main before switching. Anything else leaves whatever
+    // `CreateThread` captured, which would rewind main to its
+    // startup path.
+    //
+    // Worker stacks are carved downwards from 0x62000000 at 1 MiB
+    // apart, and main's lives below 0x60000000, so the two are
+    // trivially distinguishable by their top byte. Printing both at
+    // the moment of the switch says whether the registers being
+    // restored are a plausible continuation for main or a stale
+    // snapshot -- and whether the worker's own SP is where its stack
+    // actually is.
+    log::info!(
+        "PREEMPT thread={thread_index} worker_sp=0x{:08x} worker_pc=0x{pc:08x} \
+         -> main_sp=0x{:08x} main_pc=0x{:08x} main_lr=0x{:08x}",
+        regs[13],
+        next_regs[13],
+        next_regs[15],
+        next_regs[14],
+    );
+    state.current_thread = 0;
+    // Keep the cooperative scheduler's cursor moving, so a worker that
+    // was preempted does not immediately win the next handover ahead of
+    // its peers.
+    state.next_worker = (thread_index + 1) % thread_count.max(1);
+    for (index, value) in next_regs.iter().enumerate() {
+        cpu.write_reg(reg_by_index(index), *value)?;
+    }
+    log::debug!(
+        "preempted worker thread {thread_index} at pc=0x{pc:08x}; \
+         resuming main at 0x{:08x}",
+        next_regs[15]
+    );
+    Ok(Some(next_regs[15]))
+}
+
 pub fn run_main_loop_with_hook(
     cpu: &mut dyn Cpu,
     process: &mut Process,
@@ -2356,6 +2822,33 @@ pub fn run_main_loop_with_hook(
     // that told us; see [`PRESENT_POLL_BACKOFF`].
     let mut last_direct_frames = process.state.direct_fb_frames;
     let mut last_direct_present: Option<Instant> = None;
+    // Count of soft recoveries already attempted at each faulting
+    // address (see below) -- bounded per-address rather than
+    // one-shot, since the same crash site can legitimately recur
+    // many times across a loop that's processing many similar items
+    // (e.g. once per scanline of an image) with the same underlying
+    // bug, not just from a single guest instruction re-executing in
+    // a tight infinite loop. `RECOVERY_LIMIT_PER_ADDRESS` is the
+    // backstop against the latter -- but a genuinely unbounded loop
+    // can still cycle through *several different* faulting addresses
+    // (e.g. multiple call sites within the same outer loop) without
+    // any single one hitting its own limit, so
+    // `RECOVERY_LIMIT_TOTAL` caps the sum across every address too,
+    // ensuring a truly broken loop still fails predictably rather
+    // than running (and logging) essentially forever.
+    const RECOVERY_LIMIT_PER_ADDRESS: u32 = 10_000;
+    const RECOVERY_LIMIT_TOTAL: u32 = 20_000;
+    let mut crash_recovery_attempted: std::collections::HashMap<u32, u32> =
+        std::collections::HashMap::new();
+    let mut crash_recovery_total: u32 = 0;
+
+    /// Consecutive instruction-limit slices before the watchdog
+    /// reports a stuck guest. One slice is 1M instructions, so this is
+    /// roughly a second of pure spinning -- long enough that ordinary
+    /// decompression or level building will not trip it.
+    const SPIN_WATCHDOG_SLICES: u32 = 64;
+    let mut consecutive_limit_slices: u32 = 0;
+
     loop {
         if max_slices != 0 && slice >= max_slices {
             break;
@@ -2376,6 +2869,35 @@ pub fn run_main_loop_with_hook(
             return Ok(());
         }
         if pc < 0x1000 {
+            // A call through a null function pointer. Fatal by
+            // default, because it usually means state we failed to
+            // initialise and continuing would only corrupt more.
+            //
+            // But not always: object layouts on this platform are full
+            // of optional hooks -- progress callbacks, platform
+            // extensions, destructors -- that a reference
+            // implementation legitimately leaves unset, and a guest
+            // that calls one unconditionally would have been fine on
+            // hardware only because the slot pointed at a `bx lr` stub.
+            // `POCKETHLE_SKIP_NULL_CALLS=1` returns to `LR` instead of
+            // giving up, which answers in one run whether the missing
+            // function was load-bearing or incidental.
+            //
+            // Diagnostic only: it converts a clean stop into a game
+            // running with a silently skipped call, so anything found
+            // this way still needs the real fix.
+            if skip_null_calls() {
+                let lr = cpu.read_reg(ArmReg::Lr)?;
+                if lr >= 0x1000 {
+                    log::warn!(
+                        "guest called a null pointer at pc=0x{pc:08x}; \
+                         POCKETHLE_SKIP_NULL_CALLS is set, returning to LR=0x{lr:08x}"
+                    );
+                    cpu.write_return(0)?;
+                    pc = guest_pc(lr);
+                    continue;
+                }
+            }
             log::error!(
                 "guest jumped to NULL/low address pc=0x{pc:08x}\n{regs}",
                 regs = dump_regs(cpu),
@@ -2388,6 +2910,19 @@ pub fn run_main_loop_with_hook(
         // continuation address is kept separately in `pc`, so restore it
         // explicitly before each new slice; otherwise a return from one
         // API thunk re-enters that same thunk forever.
+        // Remember this slice's execution state ourselves.
+        //
+        // `pc` carries the ARM/Thumb interworking bit for every
+        // continuation we hand out, but unicorn does not give it back:
+        // `read_reg(Pc)` is always masked and `CPSR` does not
+        // dependably reflect `env->thumb` (a crash dump showed T clear
+        // while executing Thumb at `0x0002a7bc`). So anywhere we resume
+        // from "wherever the CPU is" rather than from an address the
+        // guest supplied -- a resumable trace point, a watchdog
+        // preemption -- we have to reapply the bit from here rather
+        // than ask. The guest can only change mode via `BX`/`BLX`, and
+        // those land on a boundary we control anyway.
+        let slice_thumb = pc & 1;
         cpu.write_reg(ArmReg::Pc, pc)?;
         // Refresh the host-managed tick page so the native
         // `GetTickCount` thunk's plain `LDR` returns a fresh
@@ -2414,16 +2949,162 @@ pub fn run_main_loop_with_hook(
                         mem = dump_mem_around(cpu, pc_now, 16),
                         stack = dump_stack_code_addrs(cpu, sp_now, 64, image_base, image_end),
                     );
+                // Best-effort recovery for a guest-code-level fault --
+                // an instruction *fetch* that decodes to garbage
+                // (INSN_INVALID), or a *memory access* to an address
+                // that was never mapped (READ_UNMAPPED /
+                // WRITE_UNMAPPED). All three stem from the same root
+                // pattern we've hit repeatedly: some destination or
+                // object pointer never got set up correctly, and the
+                // guest uses it anyway a few instructions later,
+                // whether that shows up as a bad fetch or a bad
+                // access. Memory-access failures during a single HLE
+                // *call* (e.g. `memcpy`) already fail gracefully one
+                // call at a time elsewhere in the dispatcher; this is
+                // for the same fault occurring during ordinary guest
+                // instruction execution, which previously had no
+                // recovery path at all and killed the whole session.
+                // If LR looks like a plausible return address inside
+                // the loaded image, unwind to it instead --
+                // "abandon this frame, resume the caller" is the same
+                // idea already used for the process-exit trampoline
+                // and kernel-trap addresses elsewhere in this loop.
+                let msg = e.to_string();
+                let is_recoverable_fault = msg.contains("INSN_INVALID")
+                    || msg.contains("READ_UNMAPPED")
+                    || msg.contains("WRITE_UNMAPPED");
+                // Only attempted up to RECOVERY_LIMIT_PER_ADDRESS times
+                // per faulting address so a genuinely stuck loop still
+                // terminates rather than recovering into an infinite
+                // crash cycle, while a loop that's legitimately
+                // hitting the same bug on many different items (e.g.
+                // once per scanline) can still get all the way
+                // through.
+                let attempts = crash_recovery_attempted.entry(pc_now).or_insert(0);
+                let is_recoverable_fault_attempt = is_recoverable_fault
+                    && *attempts < RECOVERY_LIMIT_PER_ADDRESS
+                    && crash_recovery_total < RECOVERY_LIMIT_TOTAL;
+                if is_recoverable_fault_attempt {
+                    *attempts += 1;
+                    crash_recovery_total += 1;
+                    if let Ok(lr) = cpu.read_reg(ArmReg::Lr) {
+                        if lr >= image_base && lr < image_end {
+                            log::warn!(
+                                "attempting recovery: unwinding to LR=0x{lr:08x} instead of terminating the session"
+                            );
+                            // The saved `LR` carries its own Thumb bit;
+                            // resuming the caller in the wrong execution
+                            // state would just fault again one
+                            // instruction later.
+                            pc = guest_pc(lr);
+                            continue;
+                        }
+                    }
+                }
                 return Err(e.into());
             }
         };
         match stop {
             StopReason::InstructionLimit => {
-                pc = cpu.read_reg(ArmReg::Pc)?;
-                log::trace!("instruction slice exhausted; resuming at 0x{pc:08x}");
+                // TEMPORARY INSTRUMENTATION: interworking check.
+                //
+                // Resuming with `slice_thumb` is sound only while
+                // slices end where we chose them to -- thunk hooks, at
+                // API boundaries, where the mode cannot have changed
+                // since the slice began. The watchdog breaks that
+                // assumption: its block hook can stop execution at any
+                // block boundary, including the one right after a `BX`
+                // that just switched mode. Reapplying the slice's
+                // starting bit then decodes Thumb as ARM or the
+                // reverse.
+                //
+                // CPSR's T bit is not authoritative either -- unicorn
+                // has been seen reporting it clear while executing
+                // Thumb -- so this is not a fix, it is a question:
+                // do the two ever disagree, and does a disagreement
+                // precede the fault? If they always agree, the theory
+                // is wrong and the damage is elsewhere.
+                // `slice_thumb` is the mode the slice STARTED in, and
+                // reapplying it is sound only while slices end where we
+                // chose them to -- thunk hooks, at API boundaries, where
+                // the mode cannot have changed in between. The watchdog
+                // breaks that: its block hook stops execution at any
+                // block boundary, including the one right after a `BX`
+                // that just switched mode. Forcing the stale bit there
+                // decodes Thumb as ARM or the reverse, and NFS
+                // Undercover -- Airplay code, interworked throughout --
+                // faults within a few hundred instructions.
+                //
+                // Neither source is authoritative on its own. CPSR's T
+                // bit has been seen clear while executing Thumb, which
+                // is why `slice_thumb` exists at all; but `slice_thumb`
+                // is stale by construction once a slice can end
+                // anywhere. When they disagree we take CPSR, because a
+                // disagreement means the guest changed mode DURING this
+                // slice -- which is precisely the case `slice_thumb`
+                // cannot represent and the CPU can.
+                let raw_pc = cpu.read_reg(ArmReg::Pc)?;
+                let cpsr_thumb = u32::from(cpu.read_reg(ArmReg::Cpsr)? & 0x20 != 0);
+                let resume_thumb = if cpsr_thumb == slice_thumb {
+                    slice_thumb
+                } else {
+                    log::warn!(
+                        "INTERWORK slice_thumb={slice_thumb} cpsr_thumb={cpsr_thumb} \
+                         raw_pc=0x{raw_pc:08x} thread={} -- mode changed mid-slice, \
+                         resuming as {}",
+                        process.state.current_thread,
+                        if cpsr_thumb == 1 { "Thumb" } else { "ARM" }
+                    );
+                    cpsr_thumb
+                };
+                pc = (raw_pc & !1) | resume_thumb;
+                log::trace!(
+                    "instruction slice exhausted; resuming at 0x{pc:08x} \
+                     (cpsr=0x{:08x})",
+                    cpu.read_reg(ArmReg::Cpsr).unwrap_or(0)
+                );
+                // TEMPORARY INSTRUMENTATION: spin watchdog.
+                //
+                // A guest loop that calls no API is invisible. It
+                // burns slice after slice, the dispatcher logs
+                // nothing above trace, and the session simply appears
+                // to freeze -- which is exactly what Rayman does the
+                // moment `vkA` starts a game. Counting consecutive
+                // slices that ended on the instruction limit finds
+                // that state, and the PC says where it is looping.
+                //
+                // Logged once per burst rather than per slice, and
+                // reset by any hook below, so ordinary long stretches
+                // of guest compute stay quiet.
+                consecutive_limit_slices += 1;
+                // A worker that burns a whole slice without calling
+                // into the HLE has no cooperative yield point, so give
+                // it a preemptive one -- otherwise a guest-side spin
+                // loop starves the main thread forever. Requires the
+                // slice watchdog (`POCKETHLE_SLICE_TIMEOUT_MS`); with
+                // it off, this arm is unreachable and behaviour is
+                // exactly as before.
+                if let Some(main_pc) = preempt_running_worker(cpu, &mut process.state, pc)? {
+                    consecutive_limit_slices = 0;
+                    pc = main_pc;
+                    continue;
+                }
+                if consecutive_limit_slices == SPIN_WATCHDOG_SLICES {
+                    log::warn!(
+                        "guest appears stuck: {SPIN_WATCHDOG_SLICES} slices \
+                         with no API call, pc=0x{pc:08x} thread={thread}\n{regs}",
+                        thread = process.state.current_thread,
+                        regs = dump_regs(cpu),
+                    );
+                }
                 continue;
             }
             StopReason::Hook(addr) => {
+                consecutive_limit_slices = 0;
+                // The stall shape preemption structurally cannot see:
+                // main polling an API in a loop while a worker stays
+                // parked. See `watch_worker_starvation`.
+                watch_worker_starvation(&process.state, addr, pc);
                 // The synthetic process-exit trampoline is reached
                 // when the guest entry point's top-level frame
                 // returns and pops the seeded `LR` value into `PC`.
@@ -2599,9 +3280,20 @@ pub fn run_main_loop_with_hook(
                                 pc = frame.lr;
                                 continue;
                             }
+                            // Args are logged alongside R0/LR so a specific
+                            // syscall (Sleep's milliseconds count,
+                            // EventModify's handle + action, etc.) can be
+                            // told apart from the others that share this
+                            // same trap address -- the trap itself only
+                            // tells us guest code called *something* here,
+                            // not which raw WinCE syscall it was.
                             log::debug!(
-                                    "kernel-trap soft-return at 0x{addr:08x} (R0=0x{r0:08x}, LR=0x{lr:08x})",
+                                    "kernel-trap soft-return at 0x{addr:08x} (R0=0x{r0:08x}, R1=0x{r1:08x}, R2=0x{r2:08x}, R3=0x{r3:08x}, SP=0x{sp:08x}, LR=0x{lr:08x})",
                                     r0 = cpu.read_reg(ArmReg::R0).unwrap_or(0),
+                                    r1 = cpu.read_reg(ArmReg::R1).unwrap_or(0),
+                                    r2 = cpu.read_reg(ArmReg::R2).unwrap_or(0),
+                                    r3 = cpu.read_reg(ArmReg::R3).unwrap_or(0),
+                                    sp = cpu.read_reg(ArmReg::Sp).unwrap_or(0),
                                     lr = cpu.read_reg(ArmReg::Lr).unwrap_or(0),
                                 );
                             let lr = cpu.read_reg(ArmReg::Lr)?;
@@ -2609,6 +3301,53 @@ pub fn run_main_loop_with_hook(
                             // Skip the frame-hook for this slice —
                             // we did not actually advance the
                             // emulator, just bounced through a trap.
+                            continue;
+                        }
+                        if is_trace_point(addr) {
+                            // Trace point: record the call and keep
+                            // going, so a whole sequence of hits is
+                            // visible rather than just the first.
+                            let sp = cpu.read_reg(ArmReg::Sp).unwrap_or(0);
+                            log::info!(
+                                "trace 0x{addr:08x}: r0=0x{r0:08x} r1=0x{r1:08x} \
+                                 r2=0x{r2:08x} r3=0x{r3:08x} lr=0x{lr:08x} sp=0x{sp:08x}",
+                                r0 = cpu.read_reg(ArmReg::R0).unwrap_or(0),
+                                r1 = cpu.read_reg(ArmReg::R1).unwrap_or(0),
+                                r2 = cpu.read_reg(ArmReg::R2).unwrap_or(0),
+                                r3 = cpu.read_reg(ArmReg::R3).unwrap_or(0),
+                                lr = cpu.read_reg(ArmReg::Lr).unwrap_or(0),
+                            );
+                            // Also dump a window of the stack, flagging
+                            // the words that look like Thumb return
+                            // addresses.
+                            //
+                            // `LR` is only trustworthy when the traced
+                            // function was entered by `BL`. Tail calls
+                            // -- `pop {r3}; bx r3`, which this codebase
+                            // is full of -- leave whatever `LR` held
+                            // from some earlier call, and chasing it
+                            // leads into unrelated code that happens to
+                            // decode. The parity is the giveaway: a
+                            // real Thumb return address is odd, so an
+                            // even `LR` at a Thumb trace point is
+                            // stale by definition.
+                            //
+                            // When that happens the return address is
+                            // still on the stack, so print enough of it
+                            // to find by eye.
+                            log_stack_window(cpu, sp);
+                            // Resume *at* the traced instruction with
+                            // one hook firing suppressed, so it runs
+                            // normally instead of being skipped.
+                            cpu.set_hook_skip_once(addr);
+                            // Trace points are registered as plain
+                            // addresses, so `addr` has no interworking
+                            // bit. Resuming on it bare drops a Thumb
+                            // guest into ARM and faults `INSN_INVALID`
+                            // on the very instruction being traced --
+                            // which made `POCKETHLE_TRACE_VA` unusable
+                            // on any mixed-mode title.
+                            pc = (addr & !1) | slice_thumb;
                             continue;
                         }
                         // Some other host-installed hook (e.g.
@@ -2629,27 +3368,52 @@ pub fn run_main_loop_with_hook(
                     DispatchOutcome::ReturnedR0(v) => {
                         cpu.write_return(v)?;
                         let lr = cpu.read_reg(ArmReg::Lr)?;
-                        pc = lr;
+                        pc = guest_pc(lr);
                     }
                     DispatchOutcome::ReturnedR0R1(a, b) => {
                         cpu.write_return_pair(a, b)?;
                         let lr = cpu.read_reg(ArmReg::Lr)?;
-                        pc = lr;
+                        pc = guest_pc(lr);
                     }
                     DispatchOutcome::Unimplemented => {
                         cpu.write_return(0)?;
                         let lr = cpu.read_reg(ArmReg::Lr)?;
-                        pc = lr;
+                        pc = guest_pc(lr);
                     }
                     DispatchOutcome::JumpTo(target) => {
                         // Trampoline into a guest function — `target` is
                         // the new PC, the handler is responsible for
-                        // setting LR / R0..R3 / SP appropriately.
-                        pc = target;
+                        // setting LR / R0..R3 / SP appropriately. The
+                        // low bit selects ARM vs Thumb, so it goes to
+                        // `CPSR.T` rather than into `PC`.
+                        pc = guest_pc(target);
                     }
                 }
             }
-            StopReason::Requested | StopReason::OutOfBounds => return Ok(()),
+            stop @ (StopReason::Requested | StopReason::OutOfBounds) => {
+                // These used to return silently, which made the most
+                // confusing failure mode in the emulator: the run
+                // thread simply ends, the last frame stays on screen,
+                // audio drains, the UI carries on, and not one line
+                // is written anywhere. Both watchdogs are blind to it
+                // -- an exited thread neither spins nor blocks.
+                //
+                // `OutOfBounds` in particular means the guest branched
+                // somewhere unmapped, which is a wild jump through a
+                // bad function pointer and a real bug worth seeing.
+                let pc_now = cpu.read_reg(ArmReg::Pc).unwrap_or(pc);
+                let sp_now = cpu.read_reg(ArmReg::Sp).unwrap_or(0);
+                let image_base = process.image.image_base;
+                let image_end = image_base.saturating_add(process.image.size_of_image);
+                log::error!(
+                    "emulation stopped: {stop:?}\n  last requested pc=0x{pc:08x}, \
+                     current pc=0x{pc_now:08x}, thread={thread}\n{regs}{stack}",
+                    thread = process.state.current_thread,
+                    regs = dump_regs(cpu),
+                    stack = dump_stack_code_addrs(cpu, sp_now, 64, image_base, image_end),
+                );
+                return Ok(());
+            }
         }
         if let Some(hook) = frame_hook.as_deref_mut() {
             // Present immediately when the guest has already announced
@@ -2873,6 +3637,10 @@ mod tests {
 
         fn write_reg(&mut self, reg: pocket_cpu::regs::ArmReg, value: u32) -> Result<(), CpuError> {
             self.inner.write_reg(reg, value)
+        }
+
+        fn set_hook_skip_once(&mut self, va: u32) {
+            self.inner.set_hook_skip_once(va)
         }
 
         fn add_code_hook(&mut self, va: u32) -> Result<(), CpuError> {

--- a/crates/pocket-kernel/src/vfs.rs
+++ b/crates/pocket-kernel/src/vfs.rs
@@ -374,7 +374,14 @@ impl Vfs {
     fn find_basename_recursive(root: &Path, wanted: &str) -> Option<PathBuf> {
         let mut pending = vec![(root.to_path_buf(), 0usize)];
         while let Some((dir, depth)) = pending.pop() {
-            let entries = std::fs::read_dir(&dir).ok()?;
+            // Skip directories we cannot read rather than abandoning the
+            // whole walk. A single unreadable subdirectory anywhere in the
+            // tree used to abort the search and report the file missing,
+            // which is indistinguishable from the file genuinely not being
+            // there and makes "not found" untrustworthy as evidence.
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
             for entry in entries.flatten() {
                 let path = entry.path();
                 let name = entry.file_name();
@@ -410,7 +417,13 @@ impl Vfs {
             .file_name()
             .map(|name| name.to_string_lossy());
         for mount in mounts {
-            let path = self.host_path_for_mount(mount, &normalised)?;
+            // Skip a mount whose escape guard rejects this path instead of
+            // failing the whole lookup. Mounts are tried longest-prefix
+            // first, so one refusal used to hide every broader mount that
+            // could still have satisfied the request.
+            let Some(path) = self.host_path_for_mount(mount, &normalised) else {
+                continue;
+            };
             if fallback.is_none() {
                 fallback = Some(path.clone());
             }
@@ -617,20 +630,47 @@ impl Vfs {
             self.volumes.insert(h, volume);
             return Some(h);
         }
+        let mut access = access;
         let host_path = if matches!(access, Access::Read) {
             self.resolve(guest_path)?
         } else {
-            let mount = self
+            let writable = self
                 .matching_mounts(&normalised)
                 .into_iter()
-                .find(|mount| !mount.read_only)?;
-            let path = self.host_path_for_mount(mount, &normalised)?;
-            if create {
-                if let Some(parent) = path.parent() {
-                    std::fs::create_dir_all(parent).ok();
+                .find(|mount| !mount.read_only)
+                .and_then(|mount| self.host_path_for_mount(mount, &normalised));
+            match writable {
+                Some(path) => {
+                    if create {
+                        if let Some(parent) = path.parent() {
+                            std::fs::create_dir_all(parent).ok();
+                        }
+                    }
+                    path
+                }
+                // No writable mount covers this path. If the file
+                // already exists on a read-only mount, open it for
+                // reading rather than failing outright.
+                //
+                // Games open their own data `"rb+"` as a matter of
+                // habit even when they only ever read it, and a game
+                // directory is mounted read-only here. Rayman Ultimate
+                // opens `PCMAP\dat\74.dat.gz` that way and retried the
+                // failing open hundreds of times, never reaching the
+                // point of drawing a menu or reading input. A write
+                // through the returned handle still fails, which is the
+                // honest outcome for a read-only mount -- but a read
+                // succeeds, which is all these titles actually need.
+                None => {
+                    let path = self.resolve(guest_path)?;
+                    log::debug!(
+                        "vfs.open({guest_path:?}) requested {access:?} but only a \
+                         read-only mount matches; falling back to read"
+                    );
+                    access = Access::Read;
+                    path
                 }
             }
-            path
         };
         let mut opts = OpenOptions::new();
         match access {
@@ -727,7 +767,7 @@ impl Vfs {
     ///
     /// This backs the CRT's `_fcloseall`. The handle table does not
     /// separate CRT streams from Win32 `CreateFile` handles, so this
-    /// closes both — which is what the process teardown this runs as part
+    /// closes both -- which is what the process teardown this runs as part
     /// of would do anyway: CeGCC's `crt3.c` calls `_fcloseall` on its way
     /// into `ExitProcess`, and nothing reads a handle after that.
     pub fn close_all(&mut self) -> usize {

--- a/crates/pocket-library/src/lib.rs
+++ b/crates/pocket-library/src/lib.rs
@@ -283,6 +283,21 @@ pub struct GameSettings {
     /// the presented frame a quarter turn is what actually works.
     #[serde(default)]
     pub rotation: RotationPref,
+    /// Wall-clock ceiling, in milliseconds, on a slice that makes no
+    /// WinCE API call -- the preemptive watchdog. `None` leaves the
+    /// engine default (or `POCKETHLE_SLICE_TIMEOUT_MS`) in charge;
+    /// `Some(0)` disables preemption for this game.
+    ///
+    /// This is per-game because titles genuinely disagree about it.
+    /// Rayman Ultimate's wait-for-button-release loop polls its own pad
+    /// state and calls nothing, so without a preemptive slice boundary
+    /// the emulator never regains control to deliver the `WM_KEYUP`
+    /// that would end it -- it needs the watchdog on. NFS Undercover
+    /// currently needs it off, because preempting a worker mid-slice
+    /// resumes it on the main thread's stack and it faults. One global
+    /// value cannot satisfy both.
+    #[serde(default)]
+    pub slice_timeout_ms: Option<u64>,
 }
 
 impl Default for GameSettings {
@@ -294,6 +309,7 @@ impl Default for GameSettings {
             halt_on_unimplemented: false,
             screen: ScreenPref::default(),
             rotation: RotationPref::default(),
+            slice_timeout_ms: None,
         }
     }
 }
@@ -736,12 +752,6 @@ impl Library {
         fs::create_dir_all(&extracted_dir)?;
 
         let (files, header) = pocket_cab::extract_with_header(cab_path, &extracted_dir)?;
-        for (index, companion) in find_resource_companion_cabs(cab_path)
-            .into_iter()
-            .enumerate()
-        {
-            import_resource_companion_cab(&game_dir, &extracted_dir, index, &companion);
-        }
         // A cabinet stores its payload under generated 8.3 names and keeps
         // the real destination names in `_setup.xml`. The game only ever
         // opens the long ones -- Asphalt 2 3D wants `light.bar` next to
@@ -764,6 +774,23 @@ impl Library {
                 header.as_ref().and_then(|h| h.app_name.as_deref()),
             );
             materialise_legacy_install_files(&extracted_dir, &files, header.as_ref());
+        }
+        // Materialising leaves the 8.3-named original beside the long
+        // name, so every payload file is present twice. That is not
+        // merely untidy: a guest sees both through its install-directory
+        // mount, and Airplay titles enumerate that directory looking for
+        // `.s3e` images. Two copies of one image reads as two games with
+        // embedded configuration, and the runtime refuses to start with
+        // "Multiple config settings found -- embedded in multiple s3e
+        // files". Because the mount covers `\Program Files\`, a second
+        // game in the same library can be poisoned by the duplicates of
+        // the first, so this cannot be left to the user to clean up.
+        let pruned = prune_materialised_duplicates(&long_names);
+        if pruned > 0 {
+            log::debug!(
+                "removed {pruned} short-name duplicates from {}",
+                extracted_dir.display()
+            );
         }
 
         let setup = files
@@ -1132,44 +1159,32 @@ impl Library {
         // ZIPs that are really just installer wrappers around a CAB —
         // recurse so we get the proper PocketPC display metadata
         // instead of a stem-derived placeholder.
-        let nested_cabs: Vec<PathBuf> = written
+        if let Some(nested_cab) = written
             .iter()
-            .filter(|p| {
+            .find(|p| {
                 p.extension()
                     .and_then(|e| e.to_str())
-                    .is_some_and(|e| e.eq_ignore_ascii_case("cab"))
+                    .map(|e| e.eq_ignore_ascii_case("cab"))
+                    .unwrap_or(false)
             })
             .cloned()
-            .collect();
-        if !nested_cabs.is_empty() {
-            let main_cab = nested_cabs
-                .iter()
-                .find(|path| {
-                    let stem = path
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or_default()
-                        .to_ascii_lowercase();
-                    !stem.contains("res") && !stem.contains("resource")
-                })
-                .cloned()
-                .unwrap_or_else(|| nested_cabs[0].clone());
+        {
             log::info!(
-                "zip {} contains nested cabinets; importing {} with its companion cabinets",
+                "zip {} contains nested cab {}, recursing",
                 zip_path.display(),
-                main_cab.display(),
+                nested_cab.display(),
             );
-            let nested_dir = self.root.join("games").join(format!(".{id}-nested-cabs"));
-            fs::create_dir_all(&nested_dir)?;
-            let staged_main =
-                nested_dir.join(main_cab.file_name().ok_or(LibraryError::NoExecutable)?);
-            for cab in &nested_cabs {
-                let name = cab.file_name().ok_or(LibraryError::NoExecutable)?;
-                fs::copy(cab, nested_dir.join(name))?;
+            // Wipe the partial extraction so the CAB import starts
+            // from a clean directory layout — the nested cab content
+            // is what we actually want as the per-game tree.
+            let nested_cab_temp = self.root.join("games").join(format!(".{id}-nested.cab"));
+            if let Some(parent) = nested_cab_temp.parent() {
+                fs::create_dir_all(parent)?;
             }
+            fs::copy(&nested_cab, &nested_cab_temp)?;
             fs::remove_dir_all(&game_dir)?;
-            let result = self.import_cab(&staged_main);
-            let _ = fs::remove_dir_all(&nested_dir);
+            let result = self.import_cab(&nested_cab_temp);
+            let _ = fs::remove_file(&nested_cab_temp);
             return result;
         }
 
@@ -1470,85 +1485,6 @@ fn record_extracted_libraries(extracted_dir: &Path, game_dir: &Path) -> Vec<Path
     found
 }
 
-fn import_resource_companion_cab(
-    game_dir: &Path,
-    extracted_dir: &Path,
-    index: usize,
-    companion: &Path,
-) {
-    let staging = game_dir.join(format!(".resource-cab-{index}"));
-    if fs::create_dir_all(&staging).is_err() {
-        return;
-    }
-    match pocket_cab::extract_with_header(companion, &staging) {
-        Ok((companion_files, companion_header)) => {
-            if let Some(header) = companion_header.as_ref().filter(|h| h.structured) {
-                pocket_cab::materialise_install_header_names(
-                    extracted_dir,
-                    &companion_files,
-                    header,
-                );
-            } else {
-                materialise_legacy_assets(
-                    extracted_dir,
-                    &companion_files,
-                    companion_header
-                        .as_ref()
-                        .and_then(|h| h.app_name.as_deref()),
-                );
-            }
-            log::info!(
-                "imported companion resource cabinet {}",
-                companion.display()
-            );
-        }
-        Err(error) => {
-            log::warn!(
-                "could not import companion resource cabinet {}: {error}",
-                companion.display()
-            );
-        }
-    }
-    let _ = fs::remove_dir_all(staging);
-}
-
-fn find_resource_companion_cabs(source: &Path) -> Vec<PathBuf> {
-    let Some(parent) = source.parent() else {
-        return Vec::new();
-    };
-    let source_stem = source
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    let family = source_stem.split(['-', '_']).next().unwrap_or(&source_stem);
-    let mut matches: Vec<PathBuf> = fs::read_dir(parent)
-        .into_iter()
-        .flatten()
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path != source)
-        .filter(|path| {
-            path.extension()
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("cab"))
-        })
-        .filter(|path| {
-            let stem = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or_default()
-                .to_ascii_lowercase();
-            stem.split(['-', '_'])
-                .next()
-                .is_some_and(|candidate| candidate == family)
-                && (stem.contains("res") || stem.contains("resource"))
-        })
-        .collect();
-    matches.sort();
-    matches
-}
-
 fn materialise_legacy_assets(root: &Path, files: &[pocket_cab::CabFile], app_name: Option<&str>) {
     let by_short: std::collections::HashMap<String, &Path> = files
         .iter()
@@ -1761,6 +1697,48 @@ fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), LibraryError> 
     Ok(())
 }
 
+fn import_resource_companion_cab(
+    game_dir: &Path,
+    extracted_dir: &Path,
+    index: usize,
+    companion: &Path,
+) {
+    let staging = game_dir.join(format!(".resource-cab-{index}"));
+    if fs::create_dir_all(&staging).is_err() {
+        return;
+    }
+    match pocket_cab::extract_with_header(companion, &staging) {
+        Ok((companion_files, companion_header)) => {
+            if let Some(header) = companion_header.as_ref().filter(|h| h.structured) {
+                pocket_cab::materialise_install_header_names(
+                    extracted_dir,
+                    &companion_files,
+                    header,
+                );
+            } else {
+                materialise_legacy_assets(
+                    extracted_dir,
+                    &companion_files,
+                    companion_header
+                        .as_ref()
+                        .and_then(|h| h.app_name.as_deref()),
+                );
+            }
+            log::info!(
+                "imported companion resource cabinet {}",
+                companion.display()
+            );
+        }
+        Err(error) => {
+            log::warn!(
+                "could not import companion resource cabinet {}: {error}",
+                companion.display()
+            );
+        }
+    }
+    let _ = fs::remove_dir_all(staging);
+}
+
 fn safe_archive_path(raw: &[u8]) -> Option<PathBuf> {
     let name = String::from_utf8_lossy(raw);
     let mut path = PathBuf::new();
@@ -1774,6 +1752,32 @@ fn safe_archive_path(raw: &[u8]) -> Option<PathBuf> {
         path.push(component);
     }
     Some(path)
+}
+
+/// Delete the 8.3-named originals whose long names were materialised.
+///
+/// `pairs` is what [`pocket_cab::materialise_setup_names`] reports:
+/// `(short, long)` absolute paths. A pair is only removed when both
+/// still exist and are genuinely different files -- if materialising
+/// renamed rather than copied, or the cabinet stored a name that was
+/// already long, there is nothing to prune and nothing is touched.
+///
+/// Returns how many files were removed, for logging.
+fn prune_materialised_duplicates(pairs: &[(PathBuf, PathBuf)]) -> usize {
+    let mut removed = 0;
+    for (short, long) in pairs {
+        if short == long || !short.exists() || !long.exists() {
+            continue;
+        }
+        match fs::remove_file(short) {
+            Ok(()) => removed += 1,
+            // Best effort: a locked or already-gone file is not worth
+            // failing an import over, and leaving it behind is exactly
+            // the state we had before this existed.
+            Err(e) => log::warn!("could not remove duplicate {}: {e}", short.display()),
+        }
+    }
+    removed
 }
 
 fn sanitize_id(stem: Option<&str>) -> String {
@@ -2338,6 +2342,30 @@ mod tests {
     }
 
     #[test]
+    fn prune_materialised_duplicates_removes_only_the_short_names() {
+        let root = tmpdir("prune");
+        fs::create_dir_all(&root).unwrap();
+        let short = root.join("NFS_UN~1.002");
+        let long = root.join("NFS Undercover.s3e");
+        let same = root.join("_setup.xml");
+        fs::write(&short, b"payload").unwrap();
+        fs::write(&long, b"payload").unwrap();
+        fs::write(&same, b"script").unwrap();
+
+        let pairs = vec![
+            (short.clone(), long.clone()),
+            // A name that was already long: short == long, nothing to do.
+            (same.clone(), same.clone()),
+            // A pair whose short side is already gone (renamed, not copied).
+            (root.join("missing.001"), long.clone()),
+        ];
+        assert_eq!(prune_materialised_duplicates(&pairs), 1);
+        assert!(!short.exists());
+        assert!(long.exists());
+        assert!(same.exists());
+    }
+
+    #[test]
     fn sanitize_id_strips_garbage() {
         assert_eq!(sanitize_id(Some("JumpyBall PPC")), "jumpyball_ppc");
         assert_eq!(sanitize_id(Some("../../etc/passwd")), "etcpasswd");
@@ -2708,17 +2736,6 @@ mod tests {
         fs::write(&stub, b"MZ").unwrap();
         assert!(!is_guest_exe(&stub));
         assert!(!is_guest_dll(&stub));
-    }
-
-    #[test]
-    fn resource_companion_cabs_are_selected_by_game_family() {
-        let root = tmpdir("resource_companion_selection");
-        fs::create_dir_all(&root).unwrap();
-        for name in ["wwp.CAB", "wwp-res.CAB", "wwp-2003.CAB", "other-res.CAB"] {
-            fs::write(root.join(name), []).unwrap();
-        }
-        let found = find_resource_companion_cabs(&root.join("wwp.CAB"));
-        assert_eq!(found, vec![root.join("wwp-res.CAB")]);
     }
 
     #[test]

--- a/crates/pocket-winceapi/src/coredll.rs
+++ b/crates/pocket-winceapi/src/coredll.rs
@@ -36,9 +36,9 @@ use pocket_kernel::{
     module_file_name, CreateStage, DispatchOutcome, GuestCallFrame, GuestThread, InputEvent,
     KernelError, KernelState, LoadedModule, ModalDialog, QsortFrame, VectorIterFrame,
     WaveCallbackKind, DEFAULT_STACK_TOP, FAKE_CURRENT_PROCESS_HANDLE, FAKE_CURRENT_THREAD_HANDLE,
-    HSS_MODULE_HANDLE, MODULE_REGION_END, MODULE_REGION_STRIDE, PROCESS_INSTANCE_HANDLE,
-    SLOT_ALIAS_BASE, SYNTHETIC_FRAMEBUFFER_BASE, THREAD_EXIT_TRAMPOLINE_BASE, TLS_SLOT_COUNT,
-    USER_KDATA_TLS_ARRAY_VA,
+    HSS_MODULE_HANDLE, HTC_SENSOR_MODULE_HANDLE, MODULE_REGION_END, MODULE_REGION_STRIDE,
+    PROCESS_INSTANCE_HANDLE, SLOT_ALIAS_BASE, SYNTHETIC_FRAMEBUFFER_BASE,
+    THREAD_EXIT_TRAMPOLINE_BASE, TLS_SLOT_COUNT, USER_KDATA_TLS_ARRAY_VA,
 };
 use pocket_pe::{ResourceEntry, ResourceKey};
 
@@ -48,6 +48,9 @@ use crate::{CallCtx, WinCeDispatcher};
 /// entry point, otherwise `hInstance == GetModuleHandle(NULL)` checks
 /// inside the game fail.
 const FAKE_MODULE_HANDLE: u32 = PROCESS_INSTANCE_HANDLE;
+/// Handle `HTCSensorOpen` reports. Opaque to the guest, which only
+/// ever hands it back to the other two entry points.
+const HTC_SENSOR_HANDLE: u32 = 0xDEAD_5E01;
 const FAKE_HWND: u32 = 0xDEAD_0001;
 /// Handle for the modeless dialog a title creates over its main window
 /// through `CreateDialogIndirectParamW`. Deliberately distinct from
@@ -85,6 +88,18 @@ fn is_live_hwnd(hwnd: u32) -> bool {
 const PAINTSTRUCT_BYTES: u32 = 32;
 
 pub fn register(d: &mut WinCeDispatcher) {
+    // HTC's tilt-sensor SDK. Nothing imports it statically -- games
+    // reach it through `LoadLibrary` + `GetProcAddress` -- so these
+    // registrations exist to make the kernel synthesize thunks for the
+    // three entry points, which is what lets the load succeed at all.
+    d.register_handler("htcsensorsdk.dll", "HTCSensorOpen", htc_sensor_open);
+    d.register_handler("htcsensorsdk.dll", "HTCSensorClose", htc_sensor_close);
+    d.register_handler(
+        "htcsensorsdk.dll",
+        "HTCSensorGetDataOutput",
+        htc_sensor_get_data_output,
+    );
+
     let dll = "coredll.dll";
 
     // ---- Process / module / library ----
@@ -185,13 +200,29 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "_strcmpi", stricmp);
     d.register_handler(dll, "_strnicmp", strnicmp);
     d.register_handler(dll, "_strncmpi", strnicmp);
+    // Same trap in block form. Unimplemented returns 0, and 0 from a
+    // compare means "equal" -- so every buffer matched every other
+    // buffer. NFS Undercover's audio thread enumerates the game
+    // directory and then compares names with this; answering "equal"
+    // makes it match the first entry it sees and go no further.
+    d.register_handler(dll, "_memicmp", memicmp);
+    d.register_handler(dll, "_memicmp_l", memicmp);
     d.register_handler(dll, "atoi", atoi_handler);
     d.register_handler(dll, "atol", atoi_handler);
     d.register_handler(dll, "atof", atof_handler);
     d.register_handler(dll, "_itoa", itoa_handler);
     d.register_handler(dll, "_itow", itow_handler);
+    // `long` is 32 bits on this target, so the `l` variants are the
+    // `i` variants under another name and can share a handler.
+    // `_ultoa` cannot: `itoa_handler` reads its argument as `i32` and
+    // would render anything from 0x80000000 up as negative.
+    d.register_handler(dll, "_ltoa", itoa_handler);
+    d.register_handler(dll, "_ltow", itow_handler);
+    d.register_handler(dll, "_ultoa", ultoa_handler);
     d.register_handler(dll, "_isctype", isctype);
     d.register_handler(dll, "strchr", strchr);
+    d.register_handler(dll, "strspn", strspn);
+    d.register_handler(dll, "strcspn", strcspn);
     d.register_handler(dll, "strrchr", strrchr);
     d.register_handler(dll, "strstr", strstr);
     d.register_handler(dll, "strspn", strspn);
@@ -219,7 +250,6 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "_wtol", wtol);
     d.register_handler(dll, "_wtoi", wtol);
     d.register_handler(dll, "CharUpperW", char_upper_w);
-    d.register_handler(dll, "_wcsupr", char_upper_w);
     d.register_handler(dll, "CharLowerW", char_lower_w);
     d.register_handler(dll, "CharUpperA", char_upper_a);
     d.register_handler(dll, "CharLowerA", char_lower_a);
@@ -269,6 +299,10 @@ pub fn register(d: &mut WinCeDispatcher) {
 
     // ---- File I/O backed by the VFS ----
     d.register_handler(dll, "CreateFileW", create_file_w);
+    d.register_handler(dll, "CreateFileForMappingW", create_file_for_mapping_w);
+    d.register_handler(dll, "CreateFileMappingW", create_file_mapping_w);
+    d.register_handler(dll, "MapViewOfFile", map_view_of_file);
+    d.register_handler(dll, "UnmapViewOfFile", unmap_view_of_file);
     d.register_handler(dll, "ReadFile", read_file);
     d.register_handler(dll, "WriteFile", write_file);
     d.register_handler(dll, "FlushFileBuffers", flush_file_buffers);
@@ -308,7 +342,19 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_constant(dll, "SetEndOfFile", 1, one_returning);
     d.register_constant(dll, "GetFileInformationByHandle", 0, zero_returning);
     d.register_constant(dll, "OpenProcess", 0, zero_returning);
-    d.register_constant(dll, "GetExitCodeProcess", 1, one_returning);
+    d.register_handler(dll, "GetExitCodeProcess", get_exit_code_process);
+    d.register_handler(dll, "GetExitCodeThread", get_exit_code_thread);
+    // BOOL: non-zero means "the signature verified". The generic
+    // unimplemented stub returns 0, which Win32 reads as a *failure*,
+    // and a caller that checks its own package signature at startup
+    // then refuses to run. NFS Undercover's Airplay runtime does
+    // exactly that: it verifies `NFS_Undercover.s3e`, is told the
+    // check failed, puts up "Incorrect signature in s3e file" and
+    // exits. We are in no position to verify anything here, and a
+    // signature check on a file the user already has is not ours to
+    // enforce.
+    d.register_constant(dll, "CryptVerifySignatureW", 1, one_returning);
+    d.register_constant(dll, "CryptVerifySignatureA", 1, one_returning);
 
     // ---- C-runtime style file I/O on top of the same VFS ----
     d.register_handler(dll, "fopen", crt_fopen);
@@ -321,7 +367,12 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "fgetpos", crt_fgetpos);
     d.register_handler(dll, "fsetpos", crt_fsetpos);
     d.register_handler(dll, "feof", crt_feof);
+    d.register_handler(dll, "ferror", crt_ferror);
+    d.register_handler(dll, "clearerr", crt_clearerr);
     d.register_handler(dll, "fflush", crt_fflush);
+    // `setvbuf` returns 0 on success, which is what the guest wants to
+    // hear: our streams are unbuffered as far as it can tell.
+    d.register_constant(dll, "setvbuf", 0, zero_returning);
     d.register_handler(dll, "_fcloseall", crt_fcloseall);
     // CeGCC's C runtime startup (`crt3.c`) calls `_fpreset` before it
     // reaches `main`; MSVC-built images never do.
@@ -566,7 +617,7 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "EndDialog", end_dialog);
     d.register_handler(dll, "MessageBoxW", message_box_w);
     d.register_handler(dll, "SetTimer", set_timer);
-    d.register_constant(dll, "KillTimer", 1, one_returning);
+    d.register_handler(dll, "KillTimer", kill_timer);
     d.register_handler(dll, "RegisterHotKey", register_hot_key);
     d.register_handler(dll, "UnregisterHotKey", unregister_hot_key);
 
@@ -606,6 +657,9 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "FillRect", fill_rect);
     d.register_handler(dll, "FrameRect", fill_rect);
     d.register_handler(dll, "DrawTextW", draw_text_w);
+    d.register_handler(dll, "GetTextExtentExPointW", get_text_extent_ex_point_w);
+    d.register_handler(dll, "GetTextExtentPoint32W", get_text_extent_ex_point_w);
+    d.register_handler(dll, "GetTextExtentPointW", get_text_extent_ex_point_w);
     d.register_constant(dll, "DrawEdge", 1, one_returning);
     d.register_constant(dll, "DrawFocusRect", 1, one_returning);
     d.register_handler(dll, "SetBkMode", set_bk_mode);
@@ -736,7 +790,8 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_constant(dll, "ImmGetContext", 0, zero_returning);
     d.register_constant(dll, "ImmReleaseContext", 1, one_returning);
     d.register_constant(dll, "ImmSetCompositionWindow", 1, one_returning);
-    d.register_constant(dll, "SystemParametersInfoW", 1, one_returning);
+    d.register_handler(dll, "SystemParametersInfoW", system_parameters_info_w);
+    d.register_handler(dll, "SystemParametersInfoA", system_parameters_info_w);
     d.register_constant(dll, "GetSystemPowerStatusEx", 1, one_returning);
     d.register_handler(dll, "CreateEventW", create_event_w);
     d.register_handler(dll, "CreateEventA", create_event_w);
@@ -756,6 +811,7 @@ pub fn register(d: &mut WinCeDispatcher) {
     d.register_handler(dll, "GetCurrentProcess", get_current_process);
     d.register_handler(dll, "GetCurrentThread", get_current_thread);
     d.register_handler(dll, "CreateThread", create_thread);
+    d.register_handler(dll, "ExitThread", exit_thread);
     d.register_handler(dll, "WaitForMultipleObjects", wait_for_multiple_objects);
     d.register_constant(dll, "SetThreadPriority", 1, one_returning);
     d.register_constant(dll, "GetThreadPriority", 0, zero_returning);
@@ -1819,6 +1875,31 @@ fn read_guest_regs(cpu: &mut dyn pocket_cpu::Cpu) -> Result<[u32; 17], KernelErr
     }
     Ok(values)
 }
+/// Normalise a parked context's saved `PC` into a jump target.
+///
+/// The saved value is *already* a correct ARM interworking address:
+/// `park_worker_at` / `resume_worker_at` store either an `LR`, which
+/// carries its own Thumb bit natively, or an explicit `resume_at`.
+/// So the bit is simply preserved, not recomputed.
+///
+/// In particular it is NOT derived from the saved `CPSR`. Unicorn's
+/// `CPSR` readback does not dependably reflect `env->thumb`: a crash
+/// dump taken while executing Thumb at `0x00028102` reported
+/// `Cpsr=0x200001d3`, T clear. Trusting that flips a resuming Thumb
+/// thread into ARM.
+///
+/// The one adjustment is the thunk region. A parked context's resume
+/// address is often not guest code at all but one of our own
+/// synthesised stubs (that is what `resume_at: Some(thunk_va)` means),
+/// and those are ARM whatever the parked thread was running.
+fn interworking_target(pc: u32) -> u32 {
+    if pc & !1 >= pocket_kernel::THUNK_REGION_BASE {
+        pc & !1
+    } else {
+        pc
+    }
+}
+
 fn write_guest_regs(cpu: &mut dyn pocket_cpu::Cpu, values: &[u32; 17]) -> Result<(), KernelError> {
     let regs = [
         ArmReg::R0,
@@ -1900,7 +1981,14 @@ fn park_worker_and_reevaluate(
 /// blocking call a worker makes is a scheduling point. `return_r0` is
 /// what that blocking call will appear to have returned once the worker
 /// is resumed. Returns `None` when the main thread is the one running.
-fn park_worker(
+/// Park the running worker and hand the CPU back to the main thread,
+/// which resumes at whatever it was doing when it scheduled this
+/// worker. `None` means the caller is not a worker, so nothing moved.
+///
+/// Visible to `gx` because a GAPI render loop reaches none of the
+/// yield points this scheduler was built around -- see
+/// `gx::gx_end_draw`.
+pub(crate) fn park_worker(
     ctx: &mut CallCtx<'_>,
     return_r0: u32,
 ) -> Result<Option<DispatchOutcome>, KernelError> {
@@ -1945,12 +2033,32 @@ fn park_worker_at(
         // see the field's doc.
         thread.parked_in_pump = resume_at.is_some();
     }
+    // TEMPORARY INSTRUMENTATION: name the parking call.
+    //
+    // A worker that parks, is rescheduled, and parks again without
+    // logging anything is invisible in the trace -- which is exactly
+    // what NFS Undercover's audio thread does, ~30 times a second,
+    // forever. The blocking APIs that park do not all log themselves,
+    // so print the thunk here: whatever the worker is waiting on names
+    // itself once, and the guessing stops.
+    log::debug!(
+        "park_worker: thread {} parked in {} (resume 0x{:08x})",
+        thread_index,
+        ctx.thunk.label(),
+        regs[15]
+    );
     ctx.kernel.current_thread = 0;
     let Some(main_regs) = main_regs else {
         return Ok(None);
     };
     write_guest_regs(ctx.cpu, &main_regs)?;
-    Ok(Some(DispatchOutcome::JumpTo(main_regs[15] & !1)))
+    // `write_guest_regs` already restored this context's `CPSR`, so
+    // re-encode its Thumb bit into the jump target -- `JumpTo` decodes
+    // bit 0 back into `CPSR.T`, and handing it a bare even address would
+    // switch a Thumb context to ARM.
+    Ok(Some(DispatchOutcome::JumpTo(interworking_target(
+        main_regs[15],
+    ))))
 }
 
 /// Hand the CPU to a worker thread that parked itself earlier.
@@ -1965,22 +2073,58 @@ fn resume_worker(
     ctx: &mut CallCtx<'_>,
     return_r0: u32,
 ) -> Result<Option<DispatchOutcome>, KernelError> {
+    resume_worker_at(ctx, Some(return_r0), None)
+}
+fn resume_worker_at(
+    ctx: &mut CallCtx<'_>,
+    return_r0: Option<u32>,
+    resume_at: Option<u32>,
+) -> Result<Option<DispatchOutcome>, KernelError> {
     if ctx.kernel.current_thread != 0 {
         return Ok(None);
     }
-    let Some((thread_index, worker_regs)) = ctx
-        .kernel
-        .threads
-        .iter()
-        .enumerate()
-        .find(|(_, thread)| thread.worker_saved && thread.started && !thread.finished)
-        .map(|(index, thread)| (index, thread.worker_regs))
+    // Rotate the search origin so eligible workers take turns.
+    //
+    // Scanning from index 0 every time means the lowest-numbered
+    // eligible worker wins every yield. That is invisible with one
+    // worker and fatal with two: a thread that parks again the moment
+    // it is scheduled -- an unsatisfied `WaitForSingleObject`, a pump
+    // whose queue is empty -- is eligible on every pass, so it absorbs
+    // the whole yield budget and the thread behind it never executes
+    // another instruction. A GAPI render thread starved this way stops
+    // calling `GXBeginDraw` entirely while the main thread carries on
+    // pumping messages and feeding audio, which reads as a graphics
+    // bug and is a scheduling one.
+    //
+    // `next_worker` advances past whoever was picked, so the round is
+    // fair regardless of how many threads park and unpark in between.
+    // Handing the same thread the CPU twice in a row is still possible
+    // when it is the only eligible one, which is what a single-worker
+    // title needs and gets.
+    let thread_count = ctx.kernel.threads.len();
+    if thread_count == 0 {
+        return Ok(None);
+    }
+    let origin = ctx.kernel.next_worker % thread_count;
+    let Some((thread_index, worker_regs)) = (0..thread_count)
+        .map(|offset| (origin + offset) % thread_count)
+        .find(|index| {
+            let thread = &ctx.kernel.threads[*index];
+            thread.worker_saved && thread.started && !thread.finished
+        })
+        .map(|index| (index, ctx.kernel.threads[index].worker_regs))
     else {
         return Ok(None);
     };
+    ctx.kernel.next_worker = (thread_index + 1) % thread_count;
     let mut main_regs = read_guest_regs(ctx.cpu)?;
-    main_regs[0] = return_r0;
-    main_regs[15] = ctx.cpu.read_reg(ArmReg::Lr)?;
+    if let Some(value) = return_r0 {
+        main_regs[0] = value;
+    }
+    main_regs[15] = match resume_at {
+        Some(va) => va,
+        None => ctx.cpu.read_reg(ArmReg::Lr)?,
+    };
     if let Some(thread) = ctx.kernel.threads.get_mut(thread_index) {
         thread.saved_regs = main_regs;
         thread.resume_pc = main_regs[15];
@@ -1994,7 +2138,9 @@ fn resume_worker(
         thread_index,
         worker_regs[15]
     );
-    Ok(Some(DispatchOutcome::JumpTo(worker_regs[15] & !1)))
+    Ok(Some(DispatchOutcome::JumpTo(interworking_target(
+        worker_regs[15],
+    ))))
 }
 
 /// Hand the CPU to a parked worker from a **blocking** wait on the main
@@ -2191,6 +2337,117 @@ fn create_process_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
         ctx.cpu.write_mem(process_info + 8, &1u32.to_le_bytes())?;
         ctx.cpu.write_mem(process_info + 12, &1u32.to_le_bytes())?;
     }
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+/// `BOOL GetExitCodeProcess(HANDLE hProcess, LPDWORD lpExitCode)`
+///
+/// `CreateProcessW` above never really launches anything -- there is no
+/// child process to have an exit code. But `WaitForSingleObject` treats
+/// the fake `0xDEAD_E101` handle as an unrecognized handle and reports
+/// it signalled immediately (see the "unknown handle" branch there), so
+/// a guest that does the natural `CreateProcess` -> `WaitForSingleObject`
+/// -> `GetExitCodeProcess` sequence believes the child already finished
+/// and immediately asks how it exited.
+///
+/// The old stub answered `TRUE` but never touched `lpExitCode`, leaving
+/// whatever was already at that address. A guest that checks the exit
+/// code for zero (a very common "did the helper process succeed"
+/// pattern -- e.g. games that shell out to a small validation/DRM-check
+/// executable before continuing) would read that leftover value as a
+/// nonzero failure and bail out right after `WinMain` starts, with no
+/// window ever created. Writing an explicit `0` here says the simulated
+/// child exited cleanly, matching what `CreateProcessW` already implies
+/// by returning success.
+fn get_exit_code_process(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let exit_code_ptr = ctx.arg_u32(1)?;
+    log::debug!("GetExitCodeProcess(0x{handle:08x}) -> 0 (simulated clean exit)");
+    if exit_code_ptr != 0 {
+        ctx.cpu.write_mem(exit_code_ptr, &0u32.to_le_bytes())?;
+    }
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+fn get_exit_code_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let exit_code_ptr = ctx.arg_u32(1)?;
+    log::debug!("GetExitCodeThread(0x{handle:08x}) -> 0 (simulated clean exit)");
+    if exit_code_ptr != 0 {
+        ctx.cpu.write_mem(exit_code_ptr, &0u32.to_le_bytes())?;
+    }
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+/// `BOOL GetTextExtentExPointW(HDC, LPCWSTR lpszStr, int cchString,
+///     int nMaxExtent, LPINT lpnFit, LPINT alpDx, LPSIZE lpSize)`
+///
+/// Measures a string, and is dangerous to leave unimplemented in a way
+/// most missing APIs are not: it reports its answers through three
+/// *output* pointers. The generic stub returns 0 and touches none of
+/// them, so the caller reads back whatever was already on its stack and
+/// indexes with it. ZIO Interactive's NFS calls this six times and then
+/// faults on `ldrh r10, [r7, r2]` with half its register file holding
+/// values like `0x95f8064c` -- stack garbage promoted to offsets.
+///
+/// The metrics come from the same fixed-width font `DrawTextW` uses, so
+/// what a caller measures agrees with what it will actually get drawn.
+fn get_text_extent_ex_point_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let str_ptr = ctx.arg_u32(1)?;
+    let count = ctx.arg_u32(2)? as i32;
+    let max_extent = ctx.arg_u32(3)? as i32;
+    let lpn_fit = ctx.arg_u32(4)?;
+    let alp_dx = ctx.arg_u32(5)?;
+    let lp_size = ctx.arg_u32(6)?;
+
+    let glyph_w = pocket_kernel::font::GLYPH_W;
+    let glyph_h = pocket_kernel::font::GLYPH_H;
+    // A negative count means "NUL-terminated", matching `DrawTextW`.
+    let chars = if count < 0 {
+        read_wstr(ctx, str_ptr, 0x1000)?
+    } else {
+        read_wstr(ctx, str_ptr, count as u32)?
+    };
+    let len = if count < 0 {
+        chars.len()
+    } else {
+        chars.len().min(count as usize)
+    };
+
+    // `alpDx[i]` is the extent of the *first i+1* characters, i.e. a
+    // running total rather than a per-character width.
+    //
+    // `nMaxExtent <= 0` means "no limit", not "nothing fits". Treating
+    // 0 as a real ceiling reports `*lpnFit = 0` for every string, and a
+    // caller that trusts it draws nothing at all: NFS High Stakes
+    // measures one character at a time with `nMaxExtent = 0` and came
+    // back with `fit=0` on all 855 calls, so its menus rendered as
+    // empty buttons.
+    let limited = max_extent > 0;
+    let mut fit = len;
+    for i in 0..len {
+        let extent = (i as i32 + 1) * glyph_w;
+        if limited && extent > max_extent && fit == len {
+            fit = i;
+        }
+        if alp_dx != 0 {
+            ctx.cpu
+                .write_mem(alp_dx + (i as u32 * 4), &extent.to_le_bytes())?;
+        }
+    }
+    if lpn_fit != 0 {
+        ctx.cpu.write_mem(lpn_fit, &(fit as u32).to_le_bytes())?;
+    }
+    if lp_size != 0 {
+        // SIZE { LONG cx; LONG cy; }
+        let cx = len as i32 * glyph_w;
+        ctx.cpu.write_mem(lp_size, &cx.to_le_bytes())?;
+        ctx.cpu.write_mem(lp_size + 4, &glyph_h.to_le_bytes())?;
+    }
+    log::debug!(
+        "GetTextExtentExPointW(len={len}, max={max_extent}) -> cx={} fit={fit}",
+        len as i32 * glyph_w
+    );
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
@@ -2461,11 +2718,38 @@ fn get_module_handle_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelE
     } else if name == "commctrl.dll" || name == "commctrl" {
         0x1000_0002
     } else if let Some(h) = gles_module_handle(&name) {
-        h
+        // When the GLES libraries are denied, report "not loaded"
+        // rather than falling through to FAKE_MODULE_HANDLE -- a
+        // non-null handle here would let a capability probe conclude
+        // the library is present after LoadLibraryW already refused.
+        if gles_disabled() {
+            0
+        } else {
+            h
+        }
     } else {
         FAKE_MODULE_HANDLE
     };
     Ok(DispatchOutcome::ReturnedR0(handle))
+}
+
+/// `POCKETHLE_NO_GLES=1` makes the emulator deny the OpenGL ES client
+/// libraries. Some Airplay/Marmalade titles ship a software-renderer
+/// data package but still select a hardware renderer whenever one is
+/// advertised, then dereference resources that package never contained.
+/// Denying the load pushes those titles back onto their software path.
+fn gles_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        matches!(
+            std::env::var("POCKETHLE_NO_GLES")
+                .unwrap_or_default()
+                .to_ascii_lowercase()
+                .as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
 }
 
 /// Map a `libGLES_*` module name to the handle
@@ -2514,6 +2798,91 @@ fn get_module_information(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kern
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
+/// Tilt reported to the guest, in the SDK's units: roughly -1000 to
+/// 1000 per axis, 0 meaning flat. `POCKETHLE_TILT_X` / `_Y` override
+/// them so tilt steering can be exercised without a real sensor.
+fn htc_tilt() -> (i16, i16, i16) {
+    fn axis(name: &str) -> i16 {
+        std::env::var(name)
+            .ok()
+            .and_then(|v| v.trim().parse::<i32>().ok())
+            .unwrap_or(0)
+            .clamp(-1000, 1000) as i16
+    }
+    // Z reads 0 held straight up and -1000 lying flat; a handset resting
+    // on a table is the sane default for a device that cannot move.
+    (axis("POCKETHLE_TILT_X"), axis("POCKETHLE_TILT_Y"), -1000)
+}
+
+/// `HANDLE HTCSensorOpen(DWORD sensor)`
+fn htc_sensor_open(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let sensor = ctx.arg_u32(0)?;
+    log::info!("HTCSensorOpen(sensor=0x{sensor:08x}) -> 0x{HTC_SENSOR_HANDLE:08x}");
+    Ok(DispatchOutcome::ReturnedR0(HTC_SENSOR_HANDLE))
+}
+
+/// `HTCSensorClose(HANDLE)`
+fn htc_sensor_close(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    log::info!("HTCSensorClose(0x{handle:08x})");
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+/// `HTCSensorGetDataOutput(HANDLE, ..., void *out)`
+///
+/// The payload is the 20-byte block the SDK is documented (by
+/// reverse-engineering, not by HTC) to return: three `i16` tilt axes,
+/// an `i16` that is always zero, then `AngleY` and `AngleX` as `u32`
+/// degrees, then a trailing word of unknown meaning.
+///
+/// The argument *order* is not documented, so rather than guess we take
+/// the first argument after the handle that looks like a writable guest
+/// pointer. The full register set is logged on the first few calls so
+/// the convention can be confirmed from a real run.
+fn htc_sensor_get_data_output(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let args = [
+        ctx.arg_u32(0)?,
+        ctx.arg_u32(1)?,
+        ctx.arg_u32(2)?,
+        ctx.arg_u32(3)?,
+    ];
+    let (tilt_x, tilt_y, tilt_z) = htc_tilt();
+    let mut data = [0u8; 20];
+    data[0..2].copy_from_slice(&tilt_x.to_le_bytes());
+    data[2..4].copy_from_slice(&tilt_y.to_le_bytes());
+    data[4..6].copy_from_slice(&tilt_z.to_le_bytes());
+    // data[6..8] is the always-zero field; angles follow.
+    data[8..12].copy_from_slice(&0u32.to_le_bytes());
+    data[12..16].copy_from_slice(&0u32.to_le_bytes());
+
+    let target = args
+        .iter()
+        .skip(1)
+        .copied()
+        .find(|&a| a >= 0x1_0000 && a != HTC_SENSOR_HANDLE);
+    let wrote = match target {
+        Some(p) => ctx.cpu.write_mem(p, &data).is_ok(),
+        None => false,
+    };
+
+    // Called every frame once tilt is on, so log the first handful and
+    // then keep quiet.
+    static SEEN: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+    let n = SEEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if n < 4 {
+        log::info!(
+            "HTCSensorGetDataOutput(r0=0x{:08x} r1=0x{:08x} r2=0x{:08x} r3=0x{:08x}) \
+             -> buffer={:?} wrote={wrote} tilt=({tilt_x},{tilt_y},{tilt_z})",
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            target.map(|p| format!("0x{p:08x}")),
+        );
+    }
+    Ok(DispatchOutcome::ReturnedR0(u32::from(wrote)))
+}
+
 fn load_library_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let path_p = ctx.arg_u32(0)?;
     let path = read_wstr(ctx, path_p, 260).unwrap_or_default();
@@ -2549,6 +2918,27 @@ fn load_library_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
         log::debug!("LoadLibraryW({name:?}) -> 0x{handle:08x} (PocketHLE HSS)");
         return Ok(DispatchOutcome::ReturnedR0(handle));
     }
+    if name.ends_with("htcsensorsdk.dll") || name == "htcsensorsdk" {
+        // HTC's tilt-sensor SDK. A title that cannot load it takes its
+        // no-accelerometer path: NFS Undercover hides its tilt-steering
+        // button entirely, which is the visible difference between
+        // PocketHLE and a real HTC handset.
+        //
+        // As with GLES, only claim success when the thunks actually
+        // exist -- otherwise every `GetProcAddress` returns null and
+        // the guest is worse off than if the load had failed.
+        let handle = if ctx
+            .kernel
+            .dynamic_exports
+            .contains_key(&HTC_SENSOR_MODULE_HANDLE)
+        {
+            HTC_SENSOR_MODULE_HANDLE
+        } else {
+            0
+        };
+        log::info!("LoadLibraryW({name:?}) -> 0x{handle:08x} (PocketHLE tilt sensor)");
+        return Ok(DispatchOutcome::ReturnedR0(handle));
+    }
     if name.ends_with("ole32.dll") || name == "ole32" {
         let handle = if ctx
             .kernel
@@ -2576,12 +2966,20 @@ fn load_library_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
         // thunks for this library — otherwise `GetProcAddress` would
         // hand back null for every entry point and the guest would be
         // worse off than if the load had failed outright.
-        let handle = if ctx.kernel.dynamic_exports.contains_key(&handle) {
+        let handle = if gles_disabled() {
+            0
+        } else if ctx.kernel.dynamic_exports.contains_key(&handle) {
             handle
         } else {
             0
         };
-        log::info!("LoadLibraryW({name:?}) -> 0x{handle:08x} (PocketHLE GLES)");
+        if gles_disabled() {
+            log::info!(
+                "LoadLibraryW({name:?}) -> 0x00000000 (PocketHLE GLES denied by POCKETHLE_NO_GLES)"
+            );
+        } else {
+            log::info!("LoadLibraryW({name:?}) -> 0x{handle:08x} (PocketHLE GLES)");
+        }
         return Ok(DispatchOutcome::ReturnedR0(handle));
     }
     // Already resident? CE hands back the same base and bumps the
@@ -2737,6 +3135,68 @@ fn write_wide_str(
     out.extend_from_slice(&0u16.to_le_bytes());
     cpu.write_mem(dst, &out)?;
     Ok((out.len() as u32 / 2).saturating_sub(1))
+}
+
+/// The platform identity reported for `SPI_GETPLATFORMTYPE`. Windows CE
+/// devices answer "PocketPC" or "SmartPhone"; override with
+/// `POCKETHLE_PLATFORM_TYPE` for a title that wants the other one.
+fn platform_type() -> String {
+    std::env::var("POCKETHLE_PLATFORM_TYPE").unwrap_or_else(|_| "PocketPC".to_string())
+}
+
+/// The device name reported for `SPI_GETOEMINFO`. ICF files match
+/// specific handsets by this string (`{ID=WINMOBILE "Dell Axim X51v"}`),
+/// so `POCKETHLE_OEM_INFO` lets a title be pointed at a device-specific
+/// block when one is needed.
+fn oem_info() -> String {
+    std::env::var("POCKETHLE_OEM_INFO").unwrap_or_else(|_| "PocketHLE".to_string())
+}
+
+/// `BOOL SystemParametersInfoW(UINT uiAction, UINT uiParam, PVOID pvParam, UINT fWinIni)`
+///
+/// Windows CE identifies the device through this call. Airplay loaders
+/// read SPI_GETPLATFORMTYPE and compare the answer against "PocketPC"
+/// and "SmartPhone", and every conditional block in an ICF file keys off
+/// the result. Returning TRUE without filling the buffer leaves the
+/// loader comparing uninitialised stack, which classifies the device as
+/// unknown and makes it discard the whole configuration file -- so the
+/// game reads back nothing for its own settings.
+fn system_parameters_info_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    const SPI_GETPLATFORMTYPE: u32 = 257;
+    const SPI_GETOEMINFO: u32 = 258;
+
+    let action = ctx.arg_u32(0)?;
+    let ui_param = ctx.arg_u32(1)?;
+    let pv_param = ctx.arg_u32(2)?;
+
+    let text = match action {
+        SPI_GETPLATFORMTYPE => platform_type(),
+        SPI_GETOEMINFO => oem_info(),
+        // Every other action keeps the previous stub behaviour.
+        _ => return Ok(DispatchOutcome::ReturnedR0(1)),
+    };
+
+    if pv_param == 0 {
+        log::debug!("SystemParametersInfoW(action={action}) -> NULL buffer");
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+
+    // uiParam is documented inconsistently across CE versions as either a
+    // byte count or a character count. Halving is exact when it means
+    // bytes and merely conservative when it means characters; either way
+    // there is ample room for these short strings.
+    let cap_chars = (ui_param / 2).max(1);
+    let needed = text.encode_utf16().count() as u32 + 1;
+    if cap_chars < needed {
+        log::debug!(
+            "SystemParametersInfoW(action={action}) -> buffer too small ({cap_chars} < {needed})"
+        );
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+
+    write_wide_str(ctx.cpu, pv_param, cap_chars, &text)?;
+    log::debug!("SystemParametersInfoW(action={action}) -> {text:?}");
+    Ok(DispatchOutcome::ReturnedR0(1))
 }
 
 fn get_module_file_name_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -3110,10 +3570,64 @@ fn soft_dtos(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
 
 // ---------- mem / string CRT ----------
 
+/// A legitimate bulk-write destination is always heap or stack --
+/// never the statically loaded image itself (.text/.rdata/.data/
+/// etc) -- or, for that matter, anywhere below it. We've seen a
+/// title (Asphalt 4) whose scanline-blit destination pointer is
+/// never correctly initialized keep incrementing an effectively-
+/// unbounded "destination" starting near zero, across thousands of
+/// calls; while it's still below the image, that just lands in
+/// unmapped memory and fails harmlessly -- but the failure path
+/// itself was expensive (this used to log every occurrence at `warn`
+/// before the destination ever reaches the image, dominating an
+/// entire frame's time on titles that hit this every frame), and
+/// once the destination climbs high enough it wraps into the
+/// image's own writable .data range and starts overwriting real
+/// program state -- up to and including other imports' own IAT
+/// entries, which is a far worse failure than the original crash
+/// this bug causes on its own. Used by both `memset` and
+/// `memcpy`/`memmove` to refuse the whole range outright, cheaply,
+/// before ever attempting the real write: a destination at or below
+/// the loaded image is never correct, regardless of which title
+/// triggers it or why.
+fn below_loaded_image(ctx: &CallCtx<'_>, dst: u32, _len: usize) -> bool {
+    let image_base = ctx.kernel.image_base;
+    if image_base == 0 {
+        return false;
+    }
+    // Refuse only destinations *below* the image base. An earlier
+    // version of this guard also refused anything inside the image,
+    // which was too broad: `.data` is legitimately writable and games
+    // routinely memset/memcpy their own globals there (Asphalt 4 does
+    // exactly that with a 0x6c-byte memset at startup, which this was
+    // silently dropping). Writes into the genuinely read-only parts
+    // of the image don't need a guard here at all -- the CPU's own
+    // page protection rejects those, which is the correct behaviour
+    // and matches real hardware. What remains worth catching is the
+    // "base pointer came out zero, so every write lands at
+    // 0 + offset" pattern, which is what this range represents.
+    dst < image_base
+}
+
 fn memset(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let dst = ctx.arg_u32(0)?;
     let val = ctx.arg_u32(1)? as u8;
     let len = ctx.arg_u32(2)? as usize;
+    if below_loaded_image(ctx, dst, len) {
+        // This can legitimately fire many thousands of times in a
+        // row within a single broken loop (see
+        // `below_loaded_image` for why) -- logging every
+        // occurrence at `warn` was itself a major performance
+        // problem: formatting and writing ~100k log lines per frame
+        // dwarfed the cost of the HLE dispatch calls themselves.
+        // `debug` costs next to nothing when the level is disabled
+        // (the default for a normal run), while still giving full
+        // detail when `RUST_LOG=debug` is set for diagnosis.
+        log::debug!(
+            "memset(dst=0x{dst:08x}, val=0x{val:02x}, len=0x{len:x}) refused: destination is below the loaded image; likely an uninitialized/corrupted destination pointer upstream"
+        );
+        return Ok(DispatchOutcome::ReturnedR0(dst));
+    }
     // Reuse the kernel-wide scratch buffer instead of allocating a
     // fresh `vec![val; len]` per call. Resize-with grows in-place
     // when we already have enough capacity from a previous call.
@@ -3131,6 +3645,16 @@ fn memcpy(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let dst = ctx.arg_u32(0)?;
     let src = ctx.arg_u32(1)?;
     let len = ctx.arg_u32(2)? as usize;
+    if below_loaded_image(ctx, dst, len) {
+        // See the matching comment in `memset` above -- `debug`
+        // rather than `warn` so a normal run doesn't pay for
+        // formatting and writing what can be many thousands of these
+        // per frame.
+        log::debug!(
+            "memcpy(dst=0x{dst:08x}, src=0x{src:08x}, len=0x{len:x}) refused: destination is below the loaded image; likely an uninitialized/corrupted destination pointer upstream"
+        );
+        return Ok(DispatchOutcome::ReturnedR0(dst));
+    }
     // The dominant Derby case is a per-scanline 480-byte copy
     // (240 px × 2 B) called ~25k times per frame. Going through
     // `read_mem` allocated a fresh 480-byte `Vec` per call, which
@@ -3141,7 +3665,19 @@ fn memcpy(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
         scratch.resize(len, 0);
     }
     ctx.cpu.read_mem_into(src, &mut scratch[..len])?;
-    ctx.cpu.write_mem(dst, &scratch[..len])?;
+    if let Err(e) = ctx.cpu.write_mem(dst, &scratch[..len]) {
+        // The generic dispatch-failure log (in lib.rs) only shows the
+        // thunk name and error, not which addresses were involved --
+        // next to useless for a destination that's unmapped outright
+        // rather than merely too-small. Log the call's own arguments
+        // before propagating, so the next run pinpoints exactly which
+        // buffer this is instead of another blind guess.
+        // debug, not warn: a single bad base pointer can produce
+        // hundreds of these per frame, and formatting them at warn
+        // level costs more than the failed copies themselves.
+        log::debug!("memcpy(dst=0x{dst:08x}, src=0x{src:08x}, len=0x{len:x}) write failed: {e}");
+        return Err(e.into());
+    }
     sync_direct_framebuffer_write(ctx, dst, len)?;
     Ok(DispatchOutcome::ReturnedR0(dst))
 }
@@ -3195,6 +3731,28 @@ fn memchr(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
         .map(|offset| ptr.wrapping_add(offset as u32))
         .unwrap_or(0);
     Ok(DispatchOutcome::ReturnedR0(result))
+}
+
+/// `int _memicmp(const void *a, const void *b, size_t n)` -- the
+/// case-insensitive block compare. ASCII folding only, which is what
+/// the CE runtime does in the C locale.
+fn memicmp(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let a = ctx.arg_u32(0)?;
+    let b = ctx.arg_u32(1)?;
+    let len = ctx.arg_u32(2)?;
+    if len == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let mut lhs = ctx.cpu.read_mem(a, len)?;
+    let mut rhs = ctx.cpu.read_mem(b, len)?;
+    lhs.make_ascii_lowercase();
+    rhs.make_ascii_lowercase();
+    let r = match lhs.cmp(&rhs) {
+        std::cmp::Ordering::Less => -1i32,
+        std::cmp::Ordering::Equal => 0,
+        std::cmp::Ordering::Greater => 1,
+    };
+    Ok(DispatchOutcome::ReturnedR0(r as u32))
 }
 
 fn memcmp(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -3490,6 +4048,34 @@ fn itoa_handler(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     }
     if negative {
         digits.push(b'-');
+    }
+    digits.reverse();
+    digits.push(0);
+    ctx.cpu.write_mem(dst, &digits)?;
+    Ok(DispatchOutcome::ReturnedR0(dst))
+}
+
+/// `_ultoa(value, buffer, radix)`.
+///
+/// The unsigned twin of [`itoa_handler`]: no sign to reproduce, and the
+/// top half of the `u32` range has to render as a large positive number
+/// rather than the negative one the signed path would produce.
+fn ultoa_handler(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let value = ctx.arg_u32(0)?;
+    let dst = ctx.arg_u32(1)?;
+    let radix = ctx.arg_u32(2)?;
+    if dst == 0 || !(2..=36).contains(&radix) {
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    let alphabet = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    let mut magnitude = value as u64;
+    let mut digits = Vec::new();
+    loop {
+        digits.push(alphabet[(magnitude % radix as u64) as usize]);
+        magnitude /= radix as u64;
+        if magnitude == 0 {
+            break;
+        }
     }
     digits.reverse();
     digits.push(0);
@@ -4627,6 +5213,23 @@ fn run_sscanf(
 /// Duty 2 runs it ~40 times during startup on material and shader
 /// definitions. Returning a bogus value here leaves the parsed structs
 /// full of stack garbage, so it is worth doing properly.
+/// `POCKETHLE_TRACE_SCANF=1` logs every `sscanf` call with its format,
+/// subject and assignment count. Noisy by design -- an ICF parse runs
+/// five format attempts per line -- so it stays off unless asked for.
+fn scanf_trace() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        matches!(
+            std::env::var("POCKETHLE_TRACE_SCANF")
+                .unwrap_or_default()
+                .to_ascii_lowercase()
+                .as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
 fn sscanf(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let src_p = ctx.arg_u32(0)?;
     let fmt_p = ctx.arg_u32(1)?;
@@ -4641,6 +5244,14 @@ fn sscanf(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
         idx += 1;
         Ok(a)
     })?;
+    if scanf_trace() {
+        log::debug!(
+            "sscanf fmt={:?} input={:?} -> {}",
+            fmt,
+            input.chars().take(80).collect::<String>(),
+            n
+        );
+    }
     Ok(DispatchOutcome::ReturnedR0(n as u32))
 }
 
@@ -5324,7 +5935,17 @@ fn close_handle(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
 fn get_file_size(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let handle = ctx.arg_u32(0)?;
     let high_p = ctx.arg_u32(1)?;
-    let size = ctx.kernel.vfs.size(handle).unwrap_or(0);
+    // A handle from `CreateFileForMappingW` is not a VFS handle, so
+    // fall back to the mapping table before giving up. Returning 0 for
+    // one of those was how Rayman Ultimate ended up allocating
+    // 0xFFFFFF80 bytes: it asked for the size of the file it had just
+    // opened for mapping, got 0, and subtracted a 128-byte header.
+    let size = ctx
+        .kernel
+        .vfs
+        .size(handle)
+        .or_else(|| mapping_file_size(handle))
+        .unwrap_or(0);
     if high_p != 0 {
         ctx.cpu
             .write_mem(high_p, &((size >> 32) as u32).to_le_bytes())?;
@@ -5450,7 +6071,11 @@ fn set_file_pointer(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
 
 // ---------- C-runtime file I/O ----------
 
-fn read_cstr_string(ctx: &mut CallCtx<'_>, p: u32, max: u32) -> Result<String, KernelError> {
+pub(crate) fn read_cstr_string(
+    ctx: &mut CallCtx<'_>,
+    p: u32,
+    max: u32,
+) -> Result<String, KernelError> {
     if p == 0 {
         return Ok(String::new());
     }
@@ -5458,7 +6083,7 @@ fn read_cstr_string(ctx: &mut CallCtx<'_>, p: u32, max: u32) -> Result<String, K
     Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
-fn open_cstr_path(ctx: &mut CallCtx<'_>, path: &str, mode: &str) -> u32 {
+pub(crate) fn open_cstr_path(ctx: &mut CallCtx<'_>, path: &str, mode: &str) -> u32 {
     use pocket_kernel::vfs::Access;
     let access = if mode.contains('+') {
         Access::ReadWrite
@@ -5506,6 +6131,30 @@ fn open_cstr_path(ctx: &mut CallCtx<'_>, path: &str, mode: &str) -> u32 {
         format!("\\Program Files\\Game\\{normalized}"),
         format!("\\Program Files\\Atomic Dreams\\{normalized}"),
     ]);
+    // Before falling back to the bare file name, retry the path under
+    // every mount with the game's hard-coded install directory swapped
+    // out but the rest of the subpath intact.
+    //
+    // A title bakes in whatever directory its setup.exe would have
+    // created, and that need not match where the host actually mounted
+    // the files: one build of Rayman Ultimate asks for
+    // `\Program Files\Game\PCMAP\Sound\fix.s00.gz` while the extraction
+    // sits under `\Program Files\RaymanUltimate\`. Keeping the
+    // `PCMAP\Sound\...` tail matters -- the bare-file-name fallback
+    // below only looks in each mount root, so it can never find a file
+    // that lives in a subdirectory.
+    let tail_after_install_dir = normalized
+        .strip_prefix("Program Files\\")
+        .or_else(|| normalized.strip_prefix("program files\\"))
+        .and_then(|rest| rest.split_once('\\'))
+        .map(|(_install_dir, tail)| tail.to_string());
+    if let Some(tail) = tail_after_install_dir {
+        if !tail.is_empty() {
+            for (prefix, _) in ctx.kernel.vfs.mounts_snapshot() {
+                candidates.push(format!("{prefix}{tail}"));
+            }
+        }
+    }
     // Last resort: look for the bare file name in every mount root.
     //
     // A game usually hard-codes the install directory a real setup.exe
@@ -5534,6 +6183,21 @@ fn open_cstr_path(ctx: &mut CallCtx<'_>, path: &str, mode: &str) -> u32 {
             return h;
         }
     }
+    // Nothing matched. Dump the mount table and everything we tried:
+    // a miss is almost always either a mount prefix that does not line
+    // up with the directory the game hard-codes, or a file that simply
+    // is not in the extraction -- and those two look identical from
+    // the guest's side.
+    log::debug!(
+        "path lookup failed for {path:?}; mounts = {:?}",
+        ctx.kernel
+            .vfs
+            .mounts_snapshot()
+            .iter()
+            .map(|(prefix, host)| format!("{prefix} -> {}", host.display()))
+            .collect::<Vec<_>>()
+    );
+    log::debug!("  candidates tried: {candidates:?}");
     log::trace!("fopen({path:?}, {mode:?}) -> NULL");
     0
 }
@@ -5731,6 +6395,35 @@ fn crt_feof(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let size = ctx.kernel.vfs.size(h).unwrap_or(0);
     let pos = ctx.kernel.vfs.seek(h, 0, SeekKind::Current).unwrap_or(0);
     Ok(DispatchOutcome::ReturnedR0(if pos >= size { 1 } else { 0 }))
+}
+
+/// `ferror(stream)` -- non-zero if the stream's error indicator is set.
+///
+/// The generic unimplemented stub also returned 0, so this looks like
+/// a no-op change, but the two differ in the case that matters: a
+/// caller holding a stream that was never opened. `fopen` returns NULL
+/// on failure, and code that then asks `ferror(NULL)` is asking
+/// "did this fail?", to which a blanket 0 answers "no, everything is
+/// fine" and lets the caller continue with a stream it does not have.
+///
+/// Report an error for any handle the VFS does not know about, which
+/// covers NULL and any stale handle, and no error for a live one --
+/// we surface read failures through the read calls themselves rather
+/// than latching a sticky flag.
+fn crt_ferror(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let h = ctx.arg_u32(0)?;
+    let bad = h == 0 || !ctx.kernel.vfs.is_open(h);
+    Ok(DispatchOutcome::ReturnedR0(if bad { 1 } else { 0 }))
+}
+
+/// `clearerr(stream)` -- clears the error and end-of-file indicators.
+///
+/// We keep no sticky indicators, so there is nothing to clear; the
+/// point of implementing it is that it returns `void` and must not
+/// leave a garbage value in `r0` for a caller that ignores the
+/// distinction.
+fn crt_clearerr(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
 }
 
 fn crt_rewind(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -6145,7 +6838,9 @@ fn do_alloc(ctx: &mut CallCtx<'_>, size: u32) -> Result<DispatchOutcome, KernelE
     }
     if std::env::var("POCKETHLE_TRACE_ALLOC").is_ok() && size >= 0x1000 {
         let lr = ctx.cpu.read_reg(pocket_cpu::regs::ArmReg::Lr).unwrap_or(0);
-        eprintln!("[trace-alloc] ptr=0x{user_ptr:08x} size=0x{size:08x} lr=0x{lr:08x}");
+        // Logged rather than printed: the GUI has no attached console,
+        // so an eprintln here is discarded and the trace looks empty.
+        log::info!("[trace-alloc] ptr=0x{user_ptr:08x} size=0x{size:08x} lr=0x{lr:08x}");
     }
     Ok(DispatchOutcome::ReturnedR0(user_ptr))
 }
@@ -6367,6 +7062,17 @@ fn create_window_ex_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
         ctx.kernel.pending_startup.push_back((WM_SHOWWINDOW, 1, 0));
         ctx.kernel.pending_startup.push_back((WM_ACTIVATE, 1, 0));
         ctx.kernel.pending_startup.push_back((WM_SETFOCUS, 0, 0));
+        // A synthetic WM_KILLFOCUS was tried here at one point to
+        // steer Asphalt 4 away from a broken scanline-blit routine
+        // (its WndProc only clears the flag guarding that routine in
+        // response to WM_KILLFOCUS). That backfired badly: WM_KILLFOCUS
+        // isn't scoped to that one code path -- it's a general
+        // app-backgrounded signal, and with no later WM_SETFOCUS to
+        // pair with it, the guest's own logic treated it as a cue to
+        // shut down immediately, right after RegisterClassW, before a
+        // window was ever created. Reverted. The crash-recovery
+        // mechanism in pocket-kernel's dispatch loop remains the
+        // actual mitigation for that routine's underlying bug.
     }
     log::debug!(
         "CreateWindowExW(class={class_name:?}) -> hwnd=0x{FAKE_HWND:08x}, wndproc=0x{wnd_proc:08x}"
@@ -7059,14 +7765,17 @@ fn dispatch_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
     } else {
         FAKE_HWND
     };
-    let wnd_proc = (ctx
+    // Keep the low bit: it is the ARM/Thumb interworking flag, not part
+    // of the address, and `DispatchOutcome::JumpTo` decodes it into
+    // `CPSR.T`. Masking it here left a mixed-mode guest (Need for Speed
+    // registers `WndProc=0x0002d701`) entering Thumb code in ARM state.
+    let wnd_proc = ctx
         .kernel
         .window_procs
         .get(&hwnd)
         .copied()
-        .unwrap_or(ctx.kernel.wnd_proc))
-        & !1;
-    if wnd_proc == 0 || lp_msg == 0 {
+        .unwrap_or(ctx.kernel.wnd_proc);
+    if wnd_proc & !1 == 0 || lp_msg == 0 {
         // No registered WndProc / no message → behave like the old
         // stub: return 0, control resumes from LR.
         return Ok(DispatchOutcome::ReturnedR0(0));
@@ -7082,10 +7791,24 @@ fn dispatch_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
     if message == WM_QUIT {
         return Ok(DispatchOutcome::ReturnedR0(0));
     }
-    log::debug!(
-        "DispatchMessageW trampoline -> WndProc(hwnd=0x{:x}, msg=0x{:x}, wp=0x{:x}, lp=0x{:x}) at 0x{:08x}",
-        hwnd, message, wparam, lparam, wnd_proc
-    );
+    // WM_TIMER with a registered TIMERPROC goes to the callback rather
+    // than the window procedure -- see `set_timer`. The callback takes
+    // (hwnd, WM_TIMER, idEvent, dwTime), which lines up with the same
+    // four registers the WndProc trampoline below already sets up, so
+    // only the jump target differs.
+    let target = if message == WM_TIMER && ctx.kernel.synthetic_timer_proc != 0 {
+        let proc = ctx.kernel.synthetic_timer_proc;
+        log::debug!(
+            "DispatchMessageW trampoline -> TIMERPROC(hwnd=0x{hwnd:x}, id=0x{wparam:x}) at 0x{proc:08x}"
+        );
+        proc
+    } else {
+        log::debug!(
+            "DispatchMessageW trampoline -> WndProc(hwnd=0x{:x}, msg=0x{:x}, wp=0x{:x}, lp=0x{:x}) at 0x{:08x}",
+            hwnd, message, wparam, lparam, wnd_proc
+        );
+        wnd_proc
+    };
     use pocket_cpu::regs::ArmReg;
     let frame = pocket_kernel::GuestCallFrame {
         args: [
@@ -7103,7 +7826,7 @@ fn dispatch_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
     ctx.cpu.write_reg(ArmReg::R2, wparam)?;
     ctx.cpu.write_reg(ArmReg::R3, lparam)?;
     ctx.cpu.write_reg(ArmReg::Lr, ctx.thunk.thunk_va)?;
-    Ok(DispatchOutcome::JumpTo(wnd_proc))
+    Ok(DispatchOutcome::JumpTo(target))
 }
 
 /// Build a synthetic `MSG` blob (28 bytes on 32-bit Windows) and write
@@ -7192,6 +7915,26 @@ fn input_to_message(ev: pocket_kernel::InputEvent) -> Option<(u32, u32, u32)> {
     }
 }
 
+/// Log an input event at the moment it is handed to the guest.
+///
+/// Whether a key reached the game was previously only visible if the
+/// game dispatched it to its window procedure -- and a game that pumps
+/// messages itself (this build of Rayman Ultimate reads `msg.message`
+/// straight off `PeekMessage` and never dispatches key messages) leaves
+/// no trace at all, which makes "the buttons do nothing" impossible to
+/// tell apart from "the buttons never arrived".
+fn log_input_message(ev: pocket_kernel::InputEvent, msg: u32, wparam: u32) {
+    match ev {
+        pocket_kernel::InputEvent::KeyDown { .. } | pocket_kernel::InputEvent::KeyUp { .. } => {
+            log::debug!("input -> guest message msg=0x{msg:x} wparam=0x{wparam:x} ({ev:?})");
+        }
+        // Pointer motion is continuous; logging every sample would
+        // drown out the events worth seeing.
+        pocket_kernel::InputEvent::PointerMove { .. } => {}
+        _ => log::debug!("input -> guest message msg=0x{msg:x} wparam=0x{wparam:x}"),
+    }
+}
+
 /// Give the built-in controls first refusal on a host input event.
 ///
 /// On a device the tap never reaches the application at all: it goes to
@@ -7264,38 +8007,62 @@ fn key_state_value(ctx: &mut CallCtx<'_>, vk: u32) -> u32 {
     } else {
         false
     };
-    let pending_state = ctx
-        .kernel
-        .pending_input
-        .iter()
-        .rev()
-        .find_map(|event| match event {
-            pocket_kernel::InputEvent::KeyDown { vk: pending } => {
-                let keys = aliases(*pending as usize);
-                Some(keys[0] == queried[0] || keys[0] == queried[1] || keys[1] == queried[0])
-            }
-            pocket_kernel::InputEvent::KeyUp { vk: pending } => {
-                let keys = aliases(*pending as usize);
-                Some(!(keys[0] == queried[0] || keys[0] == queried[1] || keys[1] == queried[0]))
-            }
-            _ => None,
-        })
-        .unwrap_or(false);
-    if pressed_now || pending_state {
-        0x8000
-    } else {
-        0
+    // There used to be a fallback here that scanned `pending_input` for
+    // the most recent key event. It was a workaround for the state not
+    // being maintained unless the guest pumped messages, and it was
+    // wrong in its own right: `rev().find_map()` stops at the newest
+    // key event of *any* virtual key, so holding Left and then tapping
+    // A made Left read as released. `push_input` keeps `pressed_keys`
+    // authoritative, so the scan is gone.
+    // 0x0001: pressed since the previous query for this key. Consume
+    // the latch here -- that is what the real API does, and leaving it
+    // set would make one tap look like several.
+    let mut latched = false;
+    for key in queried {
+        if key < ctx.kernel.keys_pressed_since_query.len()
+            && ctx.kernel.keys_pressed_since_query[key]
+        {
+            latched = true;
+            ctx.kernel.keys_pressed_since_query[key] = false;
+        }
     }
+    let mut state = 0u32;
+    if pressed_now {
+        state |= 0x8000;
+    }
+    if latched {
+        state |= 0x0001;
+    }
+    state
 }
 
 fn get_key_state(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let vk = ctx.arg_u32(0)?;
-    Ok(DispatchOutcome::ReturnedR0(key_state_value(ctx, vk)))
+    let state = key_state_value(ctx, vk);
+    // TEMPORARY INSTRUMENTATION, at debug so it shows up without
+    // turning on trace for this whole module. `GetKeyState` had no
+    // logging at all, so a guest polling through it rather than
+    // through `GetAsyncKeyState` was completely invisible in a run
+    // log. Drop this back to trace once that is ruled in or out.
+    log::debug!("GetKeyState(vk=0x{vk:02x}) -> 0x{state:04x}");
+    Ok(DispatchOutcome::ReturnedR0(state))
 }
 
 fn get_async_key_state(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let vk = ctx.arg_u32(0)?;
-    Ok(DispatchOutcome::ReturnedR0(key_state_value(ctx, vk)))
+    let state = key_state_value(ctx, vk);
+    // Which virtual keys a polling guest actually asks about is the
+    // only reliable way to know what it is waiting for -- guessing
+    // which button a menu wants, and whether the press was seen, is
+    // otherwise pure speculation. Logged at trace so it costs nothing
+    // in a normal run; a non-zero result is worth debug level because
+    // that is the moment input actually registered.
+    // TEMPORARY INSTRUMENTATION: the zero case was at trace, so a run
+    // logged at debug could not tell "the guest polled and saw
+    // nothing" apart from "the guest never polled". Those need very
+    // different fixes. Restore the trace/debug split once known.
+    log::debug!("GetAsyncKeyState(vk=0x{vk:02x}) -> 0x{state:04x}");
+    Ok(DispatchOutcome::ReturnedR0(state))
 }
 
 fn keybd_event(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -7307,9 +8074,10 @@ fn keybd_event(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     } else {
         InputEvent::KeyDown { vk }
     };
-    if ctx.kernel.pending_input.len() < 256 {
-        ctx.kernel.pending_input.push_back(event);
-    }
+    // Goes through `push_input` so a guest that synthesises its own key
+    // events sees them in `GetAsyncKeyState` too, exactly as a host key
+    // would be seen.
+    ctx.kernel.push_input(event);
     log::debug!("keybd_event(vk=0x{vk:02x}, flags=0x{flags:08x}) -> {event:?}");
     Ok(DispatchOutcome::ReturnedR0(0))
 }
@@ -7670,6 +8438,7 @@ fn next_message(ctx: &mut CallCtx<'_>) -> (u32, u32, u32, u32) {
             }
         }
         if let Some((msg, wp, lp)) = input_to_message(ev) {
+            log_input_message(ev, msg, wp);
             return (FAKE_HWND, msg, wp, lp);
         }
     }
@@ -7753,6 +8522,7 @@ fn next_message_if_due(ctx: &mut CallCtx<'_>) -> Option<(u32, u32, u32, u32)> {
             }
         }
         if let Some((msg, wp, lp)) = input_to_message(ev) {
+            log_input_message(ev, msg, wp);
             return Some((FAKE_HWND, msg, wp, lp));
         }
     }
@@ -7898,7 +8668,150 @@ fn get_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
+/// TEMPORARY INSTRUMENTATION: a once-per-second census of everything
+/// that decides whether the guest can still draw.
+///
+/// The question this exists to answer is "the game pumps messages and
+/// feeds audio at the synthetic pump rate but never calls `GXBeginDraw`
+/// -- what stopped?". There are only a few possible answers and each
+/// one shows up as a distinct column here:
+///
+/// * the render worker died          -> `finished=true`
+/// * it was suspended                -> `started=false`
+/// * it is running but idle          -> `begin`/`end` keep climbing
+/// * it is never scheduled           -> `parked=true` and `begin`
+///   frozen; then look at `pending_input`, because the yield in
+///   `get_message_w` is skipped whenever host input is queued
+/// * it is blocked somewhere else    -> `pc` is parked at an address
+///   that is not the GAPI thunk
+///
+/// `posted` and `posted_head` cover the other stall shape: a
+/// `MM_WOM_DONE` at the head of the queue that the main thread refuses
+/// (see `take_posted_message`) while no worker ever pumps for it, which
+/// wedges every message queued behind it.
+fn pump_census(ctx: &CallCtx<'_>, which: &str, calls: u64) {
+    use std::sync::atomic::Ordering;
+    let gx_begin = crate::gx::GX_BEGIN_DRAWS.load(Ordering::Relaxed);
+    let gx_end = crate::gx::GX_END_DRAWS.load(Ordering::Relaxed);
+    let gx_parked = crate::gx::GX_PARKED_WORKERS.load(Ordering::Relaxed);
+    let posted = ctx.kernel.posted_messages.len();
+    let posted_head = ctx
+        .kernel
+        .posted_messages
+        .front()
+        .map(|entry| entry.1)
+        .unwrap_or(0);
+    let eligible = ctx
+        .kernel
+        .threads
+        .iter()
+        .filter(|thread| thread.worker_saved && thread.started && !thread.finished)
+        .count();
+    log::info!(
+        "PUMP CENSUS {which} calls={calls} thread={} pending_input={} posted={posted} \
+         posted_head=0x{posted_head:03x} threads={} eligible={eligible} \
+         gx_begin={gx_begin} gx_end={gx_end} gx_parked={gx_parked} \
+         synth_count={} synth_budget={}",
+        ctx.kernel.current_thread,
+        ctx.kernel.pending_input.len(),
+        ctx.kernel.threads.len(),
+        ctx.kernel.synthetic_message_count,
+        ctx.kernel.synthetic_message_budget,
+    );
+    {
+        use std::sync::atomic::Ordering;
+        log::info!(
+            "  WAVE CENSUS open={} write={} position={} prepare={} unprepare={} reset={} \
+             close={} serviced={} retired={} pending={} kind={:?} target=0x{:08x} \
+             owner_thread={} fn_done={} cursor={} written={}",
+            wave_stats::OPEN.load(Ordering::Relaxed),
+            wave_stats::WRITE.load(Ordering::Relaxed),
+            wave_stats::POSITION.load(Ordering::Relaxed),
+            wave_stats::PREPARE.load(Ordering::Relaxed),
+            wave_stats::UNPREPARE.load(Ordering::Relaxed),
+            wave_stats::RESET.load(Ordering::Relaxed),
+            wave_stats::CLOSE.load(Ordering::Relaxed),
+            wave_stats::SERVICED.load(Ordering::Relaxed),
+            wave_stats::RETIRED.load(Ordering::Relaxed),
+            ctx.kernel.wave_out.pending.len(),
+            ctx.kernel.wave_out.callback_kind,
+            ctx.kernel.wave_out.callback_target,
+            ctx.kernel.wave_out.owner_thread,
+            ctx.kernel.wave_out.function_done.len(),
+            ctx.kernel.audio.playback_cursor(),
+            ctx.kernel.audio.written_samples(),
+        );
+        match wave_loop_get() {
+            Some(source) => log::info!(
+                "  WAVE LOOP data=0x{:08x} len={} offset={} fed={} peak={} lead={}ms",
+                source.data,
+                source.len,
+                source.offset,
+                source.fed,
+                source.peak,
+                wave_loop_lead_ms(),
+            ),
+            None => log::info!("  WAVE LOOP none"),
+        }
+    }
+    for (index, thread) in ctx.kernel.threads.iter().enumerate() {
+        log::info!(
+            "  thread[{index}] id={} handle=0x{:08x} entry=0x{:08x} started={} \
+             finished={} parked={} pc=0x{:08x} sp=0x{:08x} lr=0x{:08x} msgs={}",
+            thread.id,
+            thread.handle,
+            thread.entry,
+            thread.started,
+            thread.finished,
+            thread.worker_saved,
+            thread.worker_regs[15],
+            thread.worker_regs[13],
+            thread.worker_regs[14],
+            thread.messages.len(),
+        );
+    }
+}
+
+/// TEMPORARY INSTRUMENTATION: which guest thread is pumping messages.
+///
+/// `pending_input` is only drained on the main thread -- both pump
+/// functions handle a worker entirely from its own posted queue and
+/// return before reaching `next_message_if_due`. So a game whose pump
+/// lives on a worker can never receive host input, and nothing in the
+/// log said which thread was calling.
+///
+/// The per-call line stays rate limited, but the full census now runs
+/// on a wall-clock interval instead of a call count: a stalled game
+/// still pumps at the synthetic 16 ms rate, so one line a second is
+/// both readable and dense enough to see a counter stop moving.
+fn log_pump_thread(ctx: &CallCtx<'_>, which: &str) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CALLS: AtomicU64 = AtomicU64::new(0);
+    static NEXT_CENSUS_MS: AtomicU64 = AtomicU64::new(0);
+    let n = CALLS.fetch_add(1, Ordering::Relaxed);
+    if n < 5 || n.is_multiple_of(1000) {
+        let thread = ctx.kernel.current_thread;
+        let queued = ctx.kernel.pending_input.len();
+        let role = if thread == 0 { "main" } else { "worker" };
+        log::debug!("{which} call #{n} on thread {thread} ({role}), pending_input={queued}");
+    }
+    let now = monotonic_ms();
+    let due = NEXT_CENSUS_MS.load(Ordering::Relaxed);
+    if now >= due
+        && NEXT_CENSUS_MS
+            .compare_exchange(due, now + 1000, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    {
+        pump_census(ctx, which, n);
+    }
+}
 fn peek_message_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    // Which message call a game's main loop uses decides where it
+    // renders: PeekMessage-based loops draw on the *idle* branch,
+    // GetMessage-based loops draw inside WM_PAINT. Tracing both makes
+    // that visible when a title pumps messages without ever drawing.
+    log::trace!("PeekMessageW");
+    log_pump_thread(ctx, "PeekMessageW");
     service_wave_out(ctx)?;
     let thunk_va = ctx.thunk.thunk_va;
     if let Some(outcome) = wave_out_enter_callback(ctx, thunk_va)? {
@@ -8708,6 +9621,15 @@ fn stretch_blt_inner(
 fn adapt_panel_to_presentation(ctx: &mut CallCtx<'_>, x: i32, y: i32, cx: i32, cy: i32) {
     const MIN_EDGE: i32 = 64;
     const MAX_EDGE: i32 = 2048;
+    // Once the game has locked a DirectDraw surface, that surface's
+    // geometry is authoritative and this heuristic must not override
+    // it. Asphalt 4 blits a 242x402 padded DIB to the screen DC while
+    // its DirectDraw blits write 240-px rows; letting the GDI size win
+    // gives the panel a 484-byte stride against the game's 480-byte
+    // rows, which skews every frame into diagonal bands.
+    if ctx.kernel.fb_mapped {
+        return;
+    }
     if x != 0 || y != 0 {
         return;
     }
@@ -10399,13 +11321,47 @@ fn unregister_hot_key(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
+/// `BOOL KillTimer(HWND hWnd, UINT_PTR uIDEvent)`
+///
+/// Clears the synthetic timer *and* its TIMERPROC. Leaving a stale
+/// callback registered would let a later WM_TIMER trampoline into a
+/// function the guest has already torn down.
+fn kill_timer(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let id = ctx.arg_u32(1)?;
+    if ctx.kernel.synthetic_timer_id == id || id == 0 {
+        ctx.kernel.synthetic_timer_id = 0;
+        ctx.kernel.synthetic_timer_proc = 0;
+        ctx.kernel.synthetic_timer_next_ms = 0;
+    }
+    log::debug!("KillTimer(id={id})");
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
 fn set_timer(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let id = ctx.arg_u32(1)?;
     let interval = ctx.arg_u32(2)?.max(1);
+    // `UINT_PTR SetTimer(HWND, UINT_PTR nIDEvent, UINT uElapse, TIMERPROC lpTimerFunc)`
+    //
+    // The fourth argument used to be discarded. It decides where
+    // WM_TIMER is delivered: with a NULL TIMERPROC the message goes to
+    // the window procedure as usual, but with a non-NULL one
+    // DispatchMessage calls the TIMERPROC directly and the WndProc
+    // never sees WM_TIMER at all. A game written that way puts its
+    // per-frame work in the callback and has no WM_TIMER case in its
+    // WndProc, so throwing the pointer away leaves the timer firing
+    // into nothing.
+    let timer_proc = ctx.arg_u32(3)?;
     let final_id = if id == 0 { FAKE_TIMER_BASE } else { id };
     ctx.kernel.synthetic_timer_id = final_id;
     ctx.kernel.synthetic_timer_interval_ms = interval;
     ctx.kernel.synthetic_timer_next_ms = monotonic_ms().saturating_add(interval as u64);
+    // Stored with its interworking bit intact -- see the `WndProc`
+    // note above; the dispatch path decodes it into `CPSR.T`.
+    ctx.kernel.synthetic_timer_proc = timer_proc;
+    log::debug!(
+        "SetTimer(id={final_id}, {interval}ms, timer_proc=0x{:08x})",
+        ctx.kernel.synthetic_timer_proc
+    );
     Ok(DispatchOutcome::ReturnedR0(final_id))
 }
 
@@ -10610,9 +11566,61 @@ fn wait_for_single_object(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kern
 /// until `ResumeThread`.
 const CREATE_SUSPENDED: u32 = 0x4;
 
+/// `void ExitThread(DWORD dwExitCode)`
+///
+/// A worker that returns normally from its entry point lands on the
+/// per-thread exit trampoline that `CreateThread` planted in LR, and
+/// the kernel's dispatch loop recognises that address, restores the
+/// main thread's registers, and marks the worker finished. A worker
+/// that calls `ExitThread` instead never reaches that trampoline --
+/// and with no handler at all the generic stub simply returned, so
+/// execution ran off the end of the thread function into whatever
+/// followed it. Rayman Ultimate's loader thread does exactly this:
+/// it finishes reading its assets, calls ExitThread, and the guest
+/// then computed a garbage length (the 0xFFFFFF80 allocation) and
+/// branched to address zero.
+///
+/// Jumping to the trampoline routes the exit through the same path a
+/// normal return takes, so there is only one place that knows how to
+/// unwind a worker.
+fn exit_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let exit_code = ctx.arg_u32(0)?;
+    let Some(thread_index) = ctx.kernel.current_thread.checked_sub(1) else {
+        // The main thread calling ExitThread means the process is
+        // done; let it fall through to the process exit trampoline.
+        log::debug!("ExitThread({exit_code}) on the main thread; treating as process exit");
+        return Ok(DispatchOutcome::JumpTo(
+            pocket_kernel::PROCESS_EXIT_TRAMPOLINE_VA,
+        ));
+    };
+    let exit_va = ctx
+        .kernel
+        .threads
+        .get(thread_index)
+        .map(|thread| thread.exit_va)
+        .unwrap_or(0);
+    if exit_va == 0 {
+        log::warn!("ExitThread({exit_code}): thread {thread_index} has no exit trampoline");
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+    log::debug!(
+        "ExitThread({exit_code}) on worker {thread_index} -> exit trampoline 0x{exit_va:08x}"
+    );
+    Ok(DispatchOutcome::JumpTo(exit_va))
+}
+
 fn create_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let _security_attributes = ctx.arg_u32(0)?;
-    let stack_size = ctx.arg_u32(1)?.max(0x1000);
+    // `dwStackSize` is a *commit* hint on real Windows/CE, not the
+    // reserve: the reserve comes from the executable header (commonly
+    // 64 KB on CE) and the OS grows the committed portion on demand.
+    // Taking the caller's value literally gave Rayman's render thread
+    // the 4 KB it asked for, and its very first frame allocated a
+    // multi-kilobyte stack frame and ran straight off the bottom into
+    // unmapped memory. Thread slots are spaced 1 MB apart below, so
+    // reserving a realistic stack costs nothing but address space.
+    const MIN_THREAD_STACK: u32 = 0x10_0000 / 2; // 512 KB, half the slot spacing
+    let stack_size = ctx.arg_u32(1)?.max(MIN_THREAD_STACK);
     let entry = ctx.arg_u32(2)?;
     let parameter = ctx.arg_u32(3)?;
     let creation_flags = ctx.arg_u32(4)?;
@@ -10668,6 +11676,9 @@ fn create_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
     // next frame.
     let stack_size = stack_size.clamp(pocket_kernel::DEFAULT_STACK_SIZE, 0x100000);
     let stack_base = stack_top.saturating_sub(stack_size) & !0xfff;
+    // Executable, matching the main stack and the heap: Windows CE had
+    // no NX, and runtime-generated interworking veneers are ordinary on
+    // this platform.
     ctx.cpu.map_region(
         stack_base.saturating_sub(0x2000),
         pocket_cpu::round_up_to_page(stack_size.saturating_add(0x3000)),
@@ -10716,7 +11727,21 @@ fn create_thread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
     worker_regs[13] = stack_top - 16;
     worker_regs[14] = exit_va;
     worker_regs[15] = entry;
-    worker_regs[16] = ctx.cpu.read_reg(ArmReg::Cpsr)?;
+    // Execution state comes from the *start address*, not the creator.
+    //
+    // Bit 0 of `lpStartAddress` is the ARM/Thumb interworking flag, so
+    // a Thumb thread procedure is entered in Thumb state no matter what
+    // the calling thread happens to be running. Inheriting the
+    // creator's `CPSR` instead starts a Thumb worker in ARM state and
+    // it faults `INSN_INVALID` on its very first instruction -- which
+    // is what Need for Speed does: an ARM caller spawning a worker at
+    // `0x0002d57d`.
+    let cpsr = ctx.cpu.read_reg(ArmReg::Cpsr)?;
+    worker_regs[16] = if entry & 1 != 0 {
+        cpsr | (1 << 5)
+    } else {
+        cpsr & !(1 << 5)
+    };
     thread.worker_regs = worker_regs;
     thread.worker_saved = true;
     thread.started = !suspended;
@@ -11011,6 +12036,43 @@ fn draw_text_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     } else {
         rt
     };
+    // TEMPORARY INSTRUMENTATION: what is actually being drawn.
+    //
+    // Rayman's post-start screen runs this call 63 times a second and
+    // the picture never changes, while `mark_dirty` below keeps the
+    // frame counter climbing -- so the frontend faithfully ships a
+    // frame per iteration and every one of them looks identical. That
+    // is the signature of a draw that marks the surface dirty without
+    // putting any visible pixels on it: empty text, a rect outside
+    // the framebuffer, or a colour equal to the background. This says
+    // which.
+    let drew = surface_for_dc(ctx.kernel, hdc).is_some();
+    let text: String = String::from_utf16_lossy(&chars);
+    log::debug!(
+        "DrawTextW hdc=0x{hdc:08x} surface={drew} chars={} text={text:?} \
+         rect=({rl},{rt},{rr},{rb}) at=({x},{y}) fmt=0x{fmt:x} \
+         color=0x{color:04x} bk=0x{bk_color:04x} transparent={}",
+        chars.len(),
+        dc_meta.bk_transparent,
+    );
+    // A zero-length string paints nothing: `pixel_w` is 0, so the
+    // background fill covers no pixels and the glyph loop has nothing
+    // to walk. Marking the surface dirty anyway is not free -- it
+    // advances `Framebuffer::frame_counter`, which makes the frontend
+    // upload and present an identical frame, and makes the next
+    // `GXBeginDraw` believe the host side was touched and re-prime the
+    // whole 150 KB guest mapping. Rayman Ultimate calls this 63 times
+    // a second with an empty string, so both costs are paid every
+    // frame for a draw that changes nothing.
+    //
+    // Report the dirty only when there was something to draw. This is
+    // not a special case for empty text: a draw that produced no
+    // pixels did not dirty the surface, and saying otherwise loses the
+    // one signal that tells the presentation path a frame is worth
+    // shipping.
+    if chars.is_empty() {
+        return Ok(DispatchOutcome::ReturnedR0(glyph_h as u32));
+    }
     if let Some(mut surf) = surface_for_dc(ctx.kernel, hdc) {
         if !dc_meta.bk_transparent {
             surf.fill_rect(x, y, pixel_w, glyph_h, bk_color);
@@ -12477,7 +13539,6 @@ fn get_locale_info_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErr
     let written = write_wide_str(ctx.cpu, dst, cap, value)?;
     Ok(DispatchOutcome::ReturnedR0(written + 1))
 }
-
 fn get_acp(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     Ok(DispatchOutcome::ReturnedR0(1252))
 }
@@ -12489,6 +13550,8 @@ fn create_cursor(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
 fn destroy_cursor(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     Ok(DispatchOutcome::ReturnedR0(1))
 }
+
+// ---------- Codepage conversion ----------
 
 // ---------- Codepage conversion ----------
 //
@@ -13279,9 +14342,162 @@ fn set_clipboard_data(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelE
 const FAKE_HWAVEOUT: u32 = 0xDEAD_4001;
 const MMSYSERR_NOERROR: u32 = 0;
 
-/// `WAVEHDR.dwFlags` bits we care about.
-const WHDR_DONE: u32 = 0x1;
-const WHDR_INQUEUE: u32 = 0x4;
+/// How often each waveOut entry point is reached, reported once a
+/// second by [`pump_census`].
+///
+/// Read these with the pending queue length printed alongside them. A
+/// guest that submits one buffer and then goes quiet has either not
+/// been told the buffer finished (pending stays put) or has been told
+/// and cannot act on it (pending drains). A guest that submits one
+/// buffer and *should* go quiet is streaming through a looping header
+/// instead -- see [`WaveLoopSource`] -- and `write` staying at 1 is
+/// correct there rather than a symptom.
+pub(crate) mod wave_stats {
+    use std::sync::atomic::AtomicU64;
+
+    pub(crate) static OPEN: AtomicU64 = AtomicU64::new(0);
+    pub(crate) static WRITE: AtomicU64 = AtomicU64::new(0);
+    pub(crate) static POSITION: AtomicU64 = AtomicU64::new(0);
+    pub(crate) static PREPARE: AtomicU64 = AtomicU64::new(0);
+    pub(crate) static UNPREPARE: AtomicU64 = AtomicU64::new(0);
+    pub(crate) static RESET: AtomicU64 = AtomicU64::new(0);
+    pub(crate) static CLOSE: AtomicU64 = AtomicU64::new(0);
+    pub(crate) static RETIRED: AtomicU64 = AtomicU64::new(0);
+    pub(crate) static SERVICED: AtomicU64 = AtomicU64::new(0);
+
+    #[inline]
+    pub(crate) fn bump(counter: &AtomicU64) {
+        counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// `WAVEHDR.dwFlags` bits, matching mmsystem.h exactly.
+///
+/// `WHDR_INQUEUE` was `0x4` here, which is `WHDR_BEGINLOOP`. Besides
+/// never setting the real in-queue bit, that made `retire_wave_buffer`
+/// clear the guest's own loop flag on a buffer it had asked to repeat.
+const WHDR_DONE: u32 = 0x0000_0001;
+const WHDR_PREPARED: u32 = 0x0000_0002;
+const WHDR_BEGINLOOP: u32 = 0x0000_0004;
+const WHDR_ENDLOOP: u32 = 0x0000_0008;
+const WHDR_INQUEUE: u32 = 0x0000_0010;
+
+/// Loop group for voices submitted from a looping `WAVEHDR`, so
+/// `waveOutReset` can silence them without touching anything else.
+const WAVE_LOOP_GROUP: u32 = 1;
+
+/// How far ahead of the device we keep the ring topped up from a
+/// looping guest buffer, in milliseconds.
+///
+/// This is a compromise, not a tuning knob to maximise. The guest is
+/// writing into the same memory we are reading, ahead of where it
+/// believes the play head is; read too far ahead and we pick up bytes
+/// it has not written yet, which is silence at best and last loop's
+/// audio at worst. Too little and the device underruns between top-ups.
+/// The pump services this ~100 times a second, so 100 ms is many
+/// top-ups deep while staying well behind a mixer that runs ~34 Hz.
+const WAVE_LOOP_LEAD_MS: u32 = 100;
+
+/// Read-ahead actually used, honouring `POCKETHLE_WAVE_LEAD_MS`.
+///
+/// Exists because the right value is a property of the *title*, not of
+/// the emulator: it depends on how far ahead of the play cursor that
+/// game writes. A title that paces itself differently from the one this
+/// was tuned against will be read at offsets it has not filled yet, and
+/// the symptom is silence with every other counter looking healthy.
+/// Sweeping this in one build beats rebuilding per guess.
+fn wave_loop_lead_ms() -> u32 {
+    static CACHED: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("POCKETHLE_WAVE_LEAD_MS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u32>().ok())
+            .unwrap_or(WAVE_LOOP_LEAD_MS)
+    })
+}
+
+/// A `WAVEHDR` the guest asked us to play on a loop, tracked as a live
+/// ring in guest memory rather than copied once.
+#[derive(Clone, Copy)]
+struct WaveLoopSource {
+    /// `WAVEHDR.lpData`.
+    data: u32,
+    /// `WAVEHDR.dwBufferLength`.
+    len: u32,
+    /// Byte offset of the next chunk to read.
+    offset: u32,
+    /// Bytes handed to the mixer so far, for the log.
+    fed: u64,
+    /// Largest absolute sample value read out of the guest's buffer so
+    /// far. This is the number that matters when a title is silent:
+    /// every other counter can look healthy while the bytes being read
+    /// are all zeros, which is exactly what happens when the read-ahead
+    /// runs past what the guest has written.
+    peak: i32,
+}
+
+static WAVE_LOOP: std::sync::Mutex<Option<WaveLoopSource>> = std::sync::Mutex::new(None);
+
+fn wave_loop_get() -> Option<WaveLoopSource> {
+    WAVE_LOOP.lock().ok().and_then(|guard| *guard)
+}
+
+fn wave_loop_set(source: Option<WaveLoopSource>) {
+    if let Ok(mut guard) = WAVE_LOOP.lock() {
+        *guard = source;
+    }
+}
+
+/// Top the ring up from the guest's looping buffer.
+///
+/// Reads only what is missing, so the amount pulled per call scales
+/// with how long it has been since the last one. Wraps at the end of
+/// the buffer, which is what makes it a loop.
+fn service_wave_loop(ctx: &mut CallCtx<'_>) -> Result<(), KernelError> {
+    let Some(mut source) = wave_loop_get() else {
+        return Ok(());
+    };
+    if source.len == 0 || source.data == 0 || ctx.kernel.wave_out.paused {
+        return Ok(());
+    }
+    let fmt = ctx.kernel.wave_out_format;
+    if fmt.bits_per_sample != 16 {
+        return Ok(());
+    }
+    let channels = u32::from(fmt.channels.max(1));
+    let target_samples = (fmt.sample_rate.max(1) / 1000).max(1) * wave_loop_lead_ms() * channels;
+    let buffered = ctx.kernel.audio.buffered_samples() as u32;
+    if buffered >= target_samples {
+        return Ok(());
+    }
+    let mut wanted_bytes = (target_samples - buffered).saturating_mul(2);
+    while wanted_bytes > 0 {
+        let remaining = source.len.saturating_sub(source.offset);
+        if remaining == 0 {
+            source.offset = 0;
+            continue;
+        }
+        let chunk = wanted_bytes.min(remaining);
+        let Ok(bytes) = ctx.cpu.read_mem(source.data + source.offset, chunk) else {
+            break;
+        };
+        let mut samples = Vec::with_capacity(bytes.len() / 2);
+        for pair in bytes.chunks_exact(2) {
+            let sample = i16::from_le_bytes([pair[0], pair[1]]);
+            source.peak = source.peak.max(i32::from(sample).abs());
+            samples.push(sample);
+        }
+        ctx.kernel.audio.push_samples(&samples);
+        source.offset = source.offset.saturating_add(chunk);
+        source.fed = source.fed.saturating_add(u64::from(chunk));
+        if source.offset >= source.len {
+            source.offset = 0;
+        }
+        wanted_bytes -= chunk;
+    }
+    wave_loop_set(Some(source));
+    Ok(())
+}
 /// `MM_WOM_DONE` — "a wave-out buffer finished playing", posted to a
 /// window or thread queue depending on how `waveOutOpen` was called.
 const MM_WOM_DONE: u32 = 0x3BD;
@@ -13418,6 +14634,7 @@ fn wave_out_set_volume(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kernel
 /// asks us to *check* whether the format is supported without
 /// opening — we report success either way.
 fn wave_out_open(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    wave_stats::bump(&wave_stats::OPEN);
     let phwo = ctx.arg_u32(0)?;
     let _device_id = ctx.arg_u32(1)?;
     let pwfx = ctx.arg_u32(2)?;
@@ -13484,6 +14701,22 @@ fn wave_out_open(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
             ctx.kernel.wave_out.instance = instance;
             ctx.kernel.wave_out.owner_thread = ctx.kernel.current_thread;
         }
+        // A freshly opened device is never paused. That matters here
+        // because we model one global engine while the guest thinks it
+        // has several: NFS Undercover opens a device, submits a looping
+        // buffer, calls `waveOutPause`, and then opens a *second*
+        // device and submits on that one. It has no reason to call
+        // `waveOutRestart` -- as far as it knows its new device was
+        // never paused -- so the first device's pause silently stopped
+        // the second one.
+        //
+        // The result was a four-way deadlock: paused engine -> nothing
+        // consumed -> playback cursor stuck at 0 -> the game's mixer
+        // thread, which polls `waveOutGetPosition` in a `Sleep` loop
+        // waiting for the cursor to advance, never writes a sample, so
+        // the ring we read from stays silent forever.
+        ctx.kernel.wave_out.paused = false;
+        ctx.kernel.audio.set_paused(false);
         ctx.kernel.audio.start();
         if let Some(fmt) = requested_format {
             ctx.kernel.audio.set_guest_format(fmt);
@@ -13498,8 +14731,11 @@ fn wave_out_open(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
 /// `MMRESULT waveOutClose(HWAVEOUT)` — stop the host stream and
 /// flush any remaining samples.
 fn wave_out_close(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    wave_stats::bump(&wave_stats::CLOSE);
     let _h = ctx.arg_u32(0)?;
     retire_all_wave_buffers(ctx)?;
+    ctx.kernel.audio.stop_voice_group(WAVE_LOOP_GROUP);
+    wave_loop_set(None);
     ctx.kernel.wave_out = pocket_kernel::WaveOutState::default();
     ctx.kernel.audio.stop();
     Ok(DispatchOutcome::ReturnedR0(MMSYSERR_NOERROR))
@@ -13507,10 +14743,13 @@ fn wave_out_close(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
 
 /// `MMRESULT waveOutReset(HWAVEOUT)` — discard any queued samples.
 fn wave_out_reset(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    wave_stats::bump(&wave_stats::RESET);
     let _h = ctx.arg_u32(0)?;
     // MSDN: `waveOutReset` marks every pending buffer as done and
     // notifies the caller for each, exactly as if they had played.
     retire_all_wave_buffers(ctx)?;
+    ctx.kernel.audio.stop_voice_group(WAVE_LOOP_GROUP);
+    wave_loop_set(None);
     ctx.kernel.audio.flush();
     Ok(DispatchOutcome::ReturnedR0(MMSYSERR_NOERROR))
 }
@@ -13543,9 +14782,15 @@ fn wave_out_restart(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
 /// honour the requested unit we answer in bytes and say so in
 /// `wType`, which is what the API expects.
 fn wave_out_get_position(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    wave_stats::bump(&wave_stats::POSITION);
     let _h = ctx.arg_u32(0)?;
     let pmmt = ctx.arg_u32(1)?;
     let size = ctx.arg_u32(2)?;
+    // Asking where playback has reached is exactly the moment a buffer
+    // that has already drained should be reported finished. The message
+    // pump services these too, but a guest that polls the position
+    // instead of pumping would otherwise never see its buffer retire.
+    service_wave_out(ctx)?;
     if pmmt == 0 || size < 8 {
         return Ok(DispatchOutcome::ReturnedR0(MMSYSERR_NOERROR));
     }
@@ -13573,14 +14818,15 @@ fn wave_out_get_position(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kerne
 /// the WHDR_DONE flag so the guest's `dwFlags` ends up `WHDR_PREPARED`
 /// (`0x2`).
 fn wave_out_prepare_header(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    wave_stats::bump(&wave_stats::PREPARE);
     let _h = ctx.arg_u32(0)?;
     let p_hdr = ctx.arg_u32(1)?;
     let _cb = ctx.arg_u32(2)?;
     if p_hdr != 0 {
-        // WAVEHDR.dwFlags is at offset 16. Set WHDR_PREPARED (0x2).
+        // WAVEHDR.dwFlags is at offset 16.
         let cur = ctx.cpu.read_mem(p_hdr + 16, 4)?;
         let mut flags = u32::from_le_bytes([cur[0], cur[1], cur[2], cur[3]]);
-        flags = (flags & !0x1) | 0x2;
+        flags = (flags & !WHDR_DONE) | WHDR_PREPARED;
         ctx.cpu.write_mem(p_hdr + 16, &flags.to_le_bytes())?;
     }
     Ok(DispatchOutcome::ReturnedR0(MMSYSERR_NOERROR))
@@ -13589,6 +14835,7 @@ fn wave_out_prepare_header(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Ker
 /// `MMRESULT waveOutUnprepareHeader(HWAVEOUT, LPWAVEHDR, UINT)` —
 /// clear WHDR_PREPARED.
 fn wave_out_unprepare_header(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    wave_stats::bump(&wave_stats::UNPREPARE);
     let _h = ctx.arg_u32(0)?;
     let p_hdr = ctx.arg_u32(1)?;
     let _cb = ctx.arg_u32(2)?;
@@ -13607,6 +14854,7 @@ fn wave_out_unprepare_header(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, K
 /// `WHDR_DONE` (`0x1`) flag is set on return so the guest's send /
 /// retire logic doesn't deadlock.
 fn wave_out_write(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    wave_stats::bump(&wave_stats::WRITE);
     let _h = ctx.arg_u32(0)?;
     let p_hdr = ctx.arg_u32(1)?;
     let _cb = ctx.arg_u32(2)?;
@@ -13619,10 +14867,19 @@ fn wave_out_write(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
     //   +8   DWORD  dwBytesRecorded
     //   +12  DWORD_PTR dwUser
     //   +16  DWORD  dwFlags
-    let hdr = ctx.cpu.read_mem(p_hdr, 20)?;
+    //   +20  DWORD  dwLoops
+    let hdr = ctx.cpu.read_mem(p_hdr, 24)?;
     let p_data = u32::from_le_bytes([hdr[0], hdr[1], hdr[2], hdr[3]]);
     let n_bytes = u32::from_le_bytes([hdr[4], hdr[5], hdr[6], hdr[7]]);
     let mut flags = u32::from_le_bytes([hdr[16], hdr[17], hdr[18], hdr[19]]);
+    let loops = u32::from_le_bytes([hdr[20], hdr[21], hdr[22], hdr[23]]);
+    // A buffer tagged BEGINLOOP..ENDLOOP is played `dwLoops` times by
+    // the driver, and the guest submits nothing further -- it has
+    // already handed over the whole track. Pushing it once into the
+    // ring and reporting it finished leaves the game with no reason to
+    // ever call `waveOutWrite` again, which is exactly what NFS
+    // Undercover does: one 3-second buffer, then silence.
+    let looping = flags & WHDR_BEGINLOOP != 0 && flags & WHDR_ENDLOOP != 0 && loops != 1;
     if p_data != 0 && n_bytes > 0 {
         let bytes = ctx.cpu.read_mem(p_data, n_bytes)?;
         let fmt = ctx.kernel.wave_out_format;
@@ -13632,7 +14889,9 @@ fn wave_out_write(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
                 for chunk in bytes.chunks_exact(2) {
                     samples.push(i16::from_le_bytes([chunk[0], chunk[1]]));
                 }
-                ctx.kernel.audio.push_samples(&samples);
+                if !looping {
+                    ctx.kernel.audio.push_samples(&samples);
+                }
             }
             8 => {
                 ctx.kernel.audio.push_samples_u8(&bytes);
@@ -13641,6 +14900,31 @@ fn wave_out_write(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
                 log::debug!("waveOutWrite: unsupported bits_per_sample={other}, dropping");
             }
         }
+    }
+    if looping {
+        // A looping buffer is never "done" until `waveOutReset` or
+        // `waveOutClose` stops it, so it stays in the queue and is not
+        // added to `pending`. Reporting it finished would invite the
+        // guest to unprepare and reuse memory we are still playing.
+        //
+        // The bytes are deliberately not copied here. The guest keeps
+        // writing into this same memory for as long as the loop plays,
+        // and at the moment it submits the header it has usually
+        // written nothing at all -- so a snapshot is silence.
+        wave_loop_set(Some(WaveLoopSource {
+            data: p_data,
+            len: n_bytes,
+            offset: 0,
+            fed: 0,
+            peak: 0,
+        }));
+        log::info!(
+            "waveOutWrite hdr=0x{p_hdr:08x} data=0x{p_data:08x} bytes={n_bytes} \
+             looping dwLoops={loops} -- tracking as a live ring"
+        );
+        flags = (flags & !WHDR_DONE) | WHDR_INQUEUE;
+        ctx.cpu.write_mem(p_hdr + 16, &flags.to_le_bytes())?;
+        return Ok(DispatchOutcome::ReturnedR0(MMSYSERR_NOERROR));
     }
     // The buffer is now queued, not finished. It is retired once the
     // playback cursor reaches the end of the samples we just pushed —
@@ -13666,6 +14950,7 @@ fn wave_out_write(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
 /// Mark `hdr` as played and tell the guest about it the way it asked
 /// at `waveOutOpen` time.
 fn retire_wave_buffer(ctx: &mut CallCtx<'_>, hdr: u32) -> Result<(), KernelError> {
+    wave_stats::bump(&wave_stats::RETIRED);
     log::debug!(
         "retire hdr=0x{hdr:08x} kind={:?}",
         ctx.kernel.wave_out.callback_kind
@@ -13730,6 +15015,8 @@ fn retire_wave_buffer(ctx: &mut CallCtx<'_>, hdr: u32) -> Result<(), KernelError
 /// places a game waiting on `MM_WOM_DONE` or a `waveOutProc` call can
 /// notice one.
 fn service_wave_out(ctx: &mut CallCtx<'_>) -> Result<(), KernelError> {
+    wave_stats::bump(&wave_stats::SERVICED);
+    service_wave_loop(ctx)?;
     if !ctx.kernel.wave_out.pending.is_empty() {
         log::trace!(
             "service_wave_out pending={} cursor={} paused={}",
@@ -14687,6 +15974,184 @@ fn find_close_change_notification(ctx: &mut CallCtx<'_>) -> Result<DispatchOutco
     )))
 }
 
+// ---------- Memory-mapped files ----------
+//
+// Rayman Ultimate loads several of its assets (`letrot.pcx` among
+// them) through the CE mapping API rather than plain ReadFile, and
+// with these unimplemented the guest got a failed mapping, derived a
+// length from it, and underflowed: the log showed a request to
+// allocate 0xFFFFFF80 bytes immediately before the crash.
+//
+// The implementation is eager, like the zlib layer: the whole file is
+// read at `CreateFileForMappingW` time and a view is a fresh guest
+// region holding a copy. That is not a true shared mapping -- writes
+// through a view are never flushed back to the host file -- but these
+// titles map read-only asset data, and doing it this way avoids
+// having to fault pages in on demand.
+
+/// Guest address space set aside for mapped views. Sits above the
+/// synthetic framebuffer reservation (`0x7800_0000` + 4 MB) with room
+/// to spare.
+const FILE_VIEW_BASE: u32 = 0x7C00_0000;
+
+/// Handle spaces for the two stages of the mapping dance. Kept well
+/// away from the VFS's handles so a mix-up fails loudly.
+const MAPPING_FILE_HANDLE_BASE: u32 = 0x4D46_0000;
+const MAPPING_OBJECT_HANDLE_BASE: u32 = 0x4D4F_0000;
+
+struct MappingState {
+    /// Contents of files opened via `CreateFileForMappingW`, keyed by
+    /// the handle handed back to the guest.
+    files: std::collections::HashMap<u32, std::sync::Arc<Vec<u8>>>,
+    /// Mapping objects created over those files.
+    objects: std::collections::HashMap<u32, std::sync::Arc<Vec<u8>>>,
+    /// Views currently mapped into guest memory: base address -> size.
+    views: std::collections::HashMap<u32, u32>,
+    next_file: u32,
+    next_object: u32,
+    /// Bump allocator for view addresses.
+    next_view: u32,
+}
+
+impl MappingState {
+    fn new() -> Self {
+        Self {
+            files: std::collections::HashMap::new(),
+            objects: std::collections::HashMap::new(),
+            views: std::collections::HashMap::new(),
+            next_file: MAPPING_FILE_HANDLE_BASE,
+            next_object: MAPPING_OBJECT_HANDLE_BASE,
+            next_view: FILE_VIEW_BASE,
+        }
+    }
+}
+
+static MAPPINGS: once_cell::sync::Lazy<std::sync::Mutex<MappingState>> =
+    once_cell::sync::Lazy::new(|| std::sync::Mutex::new(MappingState::new()));
+
+/// Size of a file opened through `CreateFileForMappingW`, for the
+/// benefit of `GetFileSize` -- those handles never reach the VFS.
+fn mapping_file_size(handle: u32) -> Option<u64> {
+    MAPPINGS
+        .lock()
+        .unwrap()
+        .files
+        .get(&handle)
+        .map(|data| data.len() as u64)
+}
+
+/// `HANDLE CreateFileForMappingW(LPCWSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE)`
+fn create_file_for_mapping_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let name_p = ctx.arg_u32(0)?;
+    if name_p == 0 {
+        return Ok(DispatchOutcome::ReturnedR0(INVALID_HANDLE_VALUE));
+    }
+    let name_w = match read_wstr(ctx, name_p, 260) {
+        Ok(n) => n,
+        Err(_) => return Ok(DispatchOutcome::ReturnedR0(INVALID_HANDLE_VALUE)),
+    };
+    let path = String::from_utf16_lossy(&name_w);
+
+    // Reuse the CRT resolver so the same guest-path spellings and
+    // mount fallbacks that `fopen` handles work here too.
+    let vfs_handle = open_cstr_path(ctx, &path, "rb");
+    if vfs_handle == 0 {
+        log::debug!("CreateFileForMappingW({path:?}) -> INVALID_HANDLE_VALUE (not found)");
+        return Ok(DispatchOutcome::ReturnedR0(INVALID_HANDLE_VALUE));
+    }
+    let mut data = Vec::new();
+    let mut chunk = [0u8; 64 * 1024];
+    loop {
+        match ctx.kernel.vfs.read(vfs_handle, &mut chunk) {
+            Some(0) | None => break,
+            Some(n) => data.extend_from_slice(&chunk[..n]),
+        }
+    }
+    ctx.kernel.vfs.close(vfs_handle);
+
+    let mut state = MAPPINGS.lock().unwrap();
+    let handle = state.next_file;
+    state.next_file = state.next_file.wrapping_add(1);
+    state.files.insert(handle, std::sync::Arc::new(data));
+    let len = state.files[&handle].len();
+    log::debug!("CreateFileForMappingW({path:?}) -> 0x{handle:08x} ({len} bytes)");
+    Ok(DispatchOutcome::ReturnedR0(handle))
+}
+
+/// `HANDLE CreateFileMappingW(HANDLE, LPSECURITY_ATTRIBUTES, DWORD, DWORD, DWORD, LPCWSTR)`
+fn create_file_mapping_w(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let file_handle = ctx.arg_u32(0)?;
+    let mut state = MAPPINGS.lock().unwrap();
+    let Some(data) = state.files.get(&file_handle).cloned() else {
+        log::warn!("CreateFileMappingW(0x{file_handle:08x}): unknown file handle -> NULL");
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    };
+    let handle = state.next_object;
+    state.next_object = state.next_object.wrapping_add(1);
+    let len = data.len();
+    state.objects.insert(handle, data);
+    log::debug!("CreateFileMappingW(0x{file_handle:08x}) -> 0x{handle:08x} ({len} bytes)");
+    Ok(DispatchOutcome::ReturnedR0(handle))
+}
+
+/// `LPVOID MapViewOfFile(HANDLE, DWORD, DWORD, DWORD, DWORD)`
+fn map_view_of_file(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let object = ctx.arg_u32(0)?;
+    let offset_low = ctx.arg_u32(3)?;
+    let requested = ctx.arg_u32(4)?;
+
+    let (data, base, size) = {
+        let mut state = MAPPINGS.lock().unwrap();
+        let Some(data) = state.objects.get(&object).cloned() else {
+            log::warn!("MapViewOfFile(0x{object:08x}): unknown mapping -> NULL");
+            return Ok(DispatchOutcome::ReturnedR0(0));
+        };
+        let start = (offset_low as usize).min(data.len());
+        // A `dwNumberOfBytesToMap` of 0 means "to the end of the
+        // mapping", which is what these titles pass.
+        let avail = data.len() - start;
+        let size = if requested == 0 {
+            avail
+        } else {
+            (requested as usize).min(avail)
+        };
+        if size == 0 {
+            log::warn!("MapViewOfFile(0x{object:08x}): empty view -> NULL");
+            return Ok(DispatchOutcome::ReturnedR0(0));
+        }
+        let rounded = pocket_cpu::round_up_to_page(size as u32);
+        let base = state.next_view;
+        state.next_view = state.next_view.saturating_add(rounded);
+        state.views.insert(base, rounded);
+        (data, base, size)
+    };
+
+    ctx.cpu.map_region(
+        base,
+        pocket_cpu::round_up_to_page(size as u32),
+        Prot::READ | Prot::WRITE,
+    )?;
+    let start = offset_low as usize;
+    ctx.cpu.write_mem(base, &data[start..start + size])?;
+    log::debug!(
+        "MapViewOfFile(0x{object:08x}, offset={offset_low}) -> 0x{base:08x} ({size} bytes)"
+    );
+    Ok(DispatchOutcome::ReturnedR0(base))
+}
+
+/// `BOOL UnmapViewOfFile(LPCVOID)`
+///
+/// The region is deliberately left mapped: guests routinely keep
+/// pointers into a view a little past the unmap call, and leaving the
+/// pages readable is far friendlier than faulting. The address space
+/// is never reused, so nothing else can land there.
+fn unmap_view_of_file(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let base = ctx.arg_u32(0)?;
+    let known = MAPPINGS.lock().unwrap().views.remove(&base).is_some();
+    log::debug!("UnmapViewOfFile(0x{base:08x}) -> {}", u32::from(known));
+    Ok(DispatchOutcome::ReturnedR0(u32::from(known)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -14743,6 +16208,7 @@ mod tests {
             window_classes: std::collections::HashMap::new(),
             window_user_data: 0,
             synthetic_timer_id: 0,
+            synthetic_timer_proc: 0,
             synthetic_timer_interval_ms: 16,
             synthetic_timer_next_ms: 0,
             synthetic_paint_next_ms: 0,
@@ -14761,7 +16227,11 @@ mod tests {
             events: Default::default(),
             semaphores: Default::default(),
             current_thread: 0,
+            next_worker: 0,
             pressed_keys: [false; 256],
+            keys_pressed_since_query: [false; 256],
+            keys_release_pending: [false; 256],
+            keys_observed_down: [false; 256],
             held_keys: Vec::new(),
             key_repeat_next_ms: None,
             key_repeat_cursor: 0,
@@ -16083,6 +17553,16 @@ mod tests {
         );
     }
 
+    /// Two eligible workers must take turns.
+    ///
+    /// `resume_worker_at` used to scan from index 0, so the lowest
+    /// numbered eligible worker won every yield. A worker that parks
+    /// again the instant it is scheduled -- an unsatisfied wait, an
+    /// empty pump queue -- is eligible on every pass, so it absorbed
+    /// the entire yield budget and the worker behind it never ran
+    /// another instruction. A GAPI render thread starved that way
+    /// stops calling `GXBeginDraw` while the main thread keeps pumping
+    /// messages and feeding audio.
     /// `InvalidateRect` asks for a *future* `WM_PAINT`; it changes no
     /// pixels, so it must not advance `frame_counter`.
     ///

--- a/crates/pocket-winceapi/src/ddraw.rs
+++ b/crates/pocket-winceapi/src/ddraw.rs
@@ -151,7 +151,38 @@ pub fn register(d: &mut WinCeDispatcher) {
             "surface_get_dc" => surface_get_dc,
             "surface_is_lost" => surface_is_lost,
             "surface_lock" => surface_lock,
+            // Slot 19 in PocketHLE's table is named after the desktop
+            // IDirectDrawSurface layout, where it is GetOverlayPosition.
+            // Asphalt 4 (and, presumably, other Pocket PC titles built
+            // against the CE ddraw.h) calls this slot with Lock's exact
+            // signature -- (this, lpDestRect=NULL, lpDDSurfaceDesc,
+            // dwFlags, hEvent) -- and then reads the surface pointer
+            // back out of the descriptor it passed. The CE surface
+            // interface is trimmed relative to the desktop one, so the
+            // slot numbering does not line up. Route it to Lock; a real
+            // GetOverlayPosition call is a no-op here anyway, so the
+            // worst case for a title that genuinely wanted overlay
+            // coordinates is the same no-op it got before.
+            "surface_get_overlay_position" => surface_lock,
             "surface_unlock" => surface_unlock,
+            // Slot 26, `ReleaseDC` in the desktop naming, is the other
+            // half of the same shift. Desktop `Lock` is slot 25 and the
+            // CE guests call it at 19 -- six lower. Desktop `Unlock` is
+            // slot 32, and 32 - 6 = 26, which lands exactly here. NFS
+            // Undercover confirms the pairing: across a whole session it
+            // calls slot 19 once and slot 26 once, and nothing else.
+            //
+            // This matters more than a missing no-op, because
+            // `surface_unlock` is the only thing that marks the
+            // framebuffer dirty. Routed to the generic `surface_ok`, a
+            // game locks the surface, renders into it, "unlocks", and
+            // never presents a single frame -- which looks from outside
+            // exactly like a game that renders nothing at all.
+            //
+            // A genuine `ReleaseDC` after `GetDC` also wants the same
+            // treatment (publish what was drawn), so this is the right
+            // behaviour for both readings of the slot.
+            "surface_release_dc" => surface_unlock,
             "surface_get_dd_interface" => surface_get_dd_interface,
             "surface_page_lock" | "surface_page_unlock" | "surface_set_surface_desc" => surface_ok,
             _ if name.starts_with("surface_") => surface_ok,
@@ -388,20 +419,82 @@ fn write_surface_desc(ctx: &mut CallCtx<'_>, desc: u32, surface: u32) -> Result<
     if desc == 0 {
         return Ok(());
     }
+    // `dwSize` of 124 means this is a DDSURFACEDESC2, whose layout is:
+    //   0   dwSize            28  dwAlphaBitDepth   72  ddpfPixelFormat (32 B)
+    //   4   dwFlags           32  dwReserved       104  ddsCaps2 (16 B)
+    //   8   dwHeight          36  lpSurface        120  dwTextureStage
+    //  12   dwWidth           40  ddckCKDestOverlay
+    //  16   lPitch            48  ddckCKDestBlt
+    //  20   dwBackBufferCount 56  ddckCKSrcOverlay
+    //  24   dwMipMapCount     64  ddckCKSrcBlt
+    // Honour the caller's `dwSize`.
+    //
+    // DirectDraw's contract is that the *caller* sets `dwSize` and the
+    // callee fills at most that many bytes. Writing a fixed 124
+    // overruns any guest using the smaller layout -- and these
+    // descriptors are almost always stack locals, so the overrun lands
+    // in the caller's live frame. NFS Undercover passed a descriptor at
+    // `0x5ffff8c0` with `SP=0x5ffff938`: 124 bytes reached
+    // `0x5ffff93c`, four bytes past `SP`, and the function returned
+    // through a smashed `LR` into its own stack.
+    //
+    // Clamp to what the caller declared, floor it at the offsets we
+    // must fill for Lock to be useful (`lpSurface` at 32 and 36), and
+    // leave the caller's own `dwSize` value intact rather than
+    // rewriting it to 124.
+    let declared =
+        u32::from_le_bytes(ctx.cpu.read_mem(desc, 4)?.try_into().unwrap_or([0u8; 4])) as usize;
+    let size = if (40..=124).contains(&declared) {
+        declared
+    } else {
+        // Nothing sane declared: fall back to the larger layout, which
+        // is what the previous unconditional write assumed.
+        124
+    };
     let mut bytes = [0u8; 124];
-    bytes[0..4].copy_from_slice(&124u32.to_le_bytes());
-    bytes[4..8].copy_from_slice(&0x0000_100fu32.to_le_bytes());
+    bytes[0..4].copy_from_slice(&(size as u32).to_le_bytes());
+    // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PITCH
+    //   | DDSD_LPSURFACE (0x800) | DDSD_PIXELFORMAT (0x1000).
+    //
+    // DDSD_LPSURFACE was missing here. We were filling in `lpSurface`
+    // at offset 36 correctly, but never telling the caller the field
+    // was valid -- and a guest that checks the flag before trusting
+    // the pointer (which is the documented contract for Lock) reads
+    // the flag as clear, ignores our pointer, and ends up blitting
+    // against a base of zero. Asphalt 4 does exactly that: every
+    // scanline of its splash blit lands at `0 + row_offset`, which is
+    // why the destinations we saw walking up from 0x0000 in 0x1e0
+    // steps looked like plain offsets rather than addresses.
+    bytes[4..8].copy_from_slice(&0x0000_180fu32.to_le_bytes());
     bytes[8..12].copy_from_slice(&ctx.kernel.framebuffer.height.to_le_bytes());
     bytes[12..16].copy_from_slice(&ctx.kernel.framebuffer.width.to_le_bytes());
     bytes[16..20].copy_from_slice(&ctx.kernel.framebuffer.stride_bytes().to_le_bytes());
+    // lpSurface: written at BOTH 32 and 36.
+    //
+    // The DirectX 1-3 era DDSURFACEDESC has no dwReserved member, so
+    // lpSurface sits at 32; the later layout inserts dwReserved and
+    // pushes it to 36. Asphalt 4 demonstrably reads it at 32 (it
+    // passes a descriptor at sb+0x164 and then loads its blit base
+    // from sb+0x184, i.e. desc+32), while the 108-byte descriptor it
+    // memsets matches the *later* layout's size. Rather than bet on
+    // one reading, fill both slots -- offset 36 is only a color-key
+    // field in the earlier layout, and a Lock output descriptor is
+    // the caller's scratch buffer either way, so the redundant write
+    // is harmless.
+    bytes[32..36].copy_from_slice(&surface.to_le_bytes());
     bytes[36..40].copy_from_slice(&surface.to_le_bytes());
-    bytes[56..60].copy_from_slice(&32u32.to_le_bytes());
-    bytes[60..64].copy_from_slice(&0x40u32.to_le_bytes());
-    bytes[68..72].copy_from_slice(&16u32.to_le_bytes());
-    bytes[72..76].copy_from_slice(&0xf800u32.to_le_bytes());
-    bytes[76..80].copy_from_slice(&0x07e0u32.to_le_bytes());
-    bytes[80..84].copy_from_slice(&0x001fu32.to_le_bytes());
-    ctx.cpu.write_mem(desc, &bytes)?;
+    // ddpfPixelFormat starts at 72, not 56. The four DDCOLORKEY
+    // members before it are 8 bytes each and span 40..72, so the old
+    // base wrote the whole pixel-format block over ddckCKSrcOverlay
+    // and ddckCKSrcBlt, leaving the real pixel format all zeroes.
+    bytes[72..76].copy_from_slice(&32u32.to_le_bytes()); // dwSize
+    bytes[76..80].copy_from_slice(&0x40u32.to_le_bytes()); // DDPF_RGB
+    bytes[84..88].copy_from_slice(&16u32.to_le_bytes()); // dwRGBBitCount
+    bytes[88..92].copy_from_slice(&0xf800u32.to_le_bytes()); // R mask
+    bytes[92..96].copy_from_slice(&0x07e0u32.to_le_bytes()); // G mask
+    bytes[96..100].copy_from_slice(&0x001fu32.to_le_bytes()); // B mask
+    log::debug!("write_surface_desc: desc=0x{desc:08x} declared={declared} writing {size} bytes");
+    ctx.cpu.write_mem(desc, &bytes[..size])?;
     Ok(())
 }
 
@@ -415,6 +508,15 @@ fn surface_get_color_key(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kerne
 
 fn surface_desc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let desc = ctx.arg_u32(1)?;
+    // NOTE: this guard skips the write entirely for any `desc` in
+    // 0x50000000..0x5f000000 -- which is the heap range in this
+    // environment. A guest that hands us a heap-allocated
+    // DDSURFACEDESC therefore gets nothing written, leaving
+    // `lpSurface` at whatever was already there (usually zero).
+    // Logging both branches so we can see which one a given title
+    // actually takes before deciding whether the guard is load-bearing.
+    let skipped = desc != 0 && (0x5000_0000..0x5f00_0000).contains(&desc);
+    log::debug!("surface_desc: desc=0x{desc:08x} skipped_by_heap_guard={skipped}");
     if desc != 0 && !(0x5000_0000..0x5f00_0000).contains(&desc) {
         write_surface_desc(ctx, desc, SYNTHETIC_FRAMEBUFFER_BASE)?;
     }
@@ -423,6 +525,7 @@ fn surface_desc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
 
 fn surface_get_dc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let out = ctx.arg_u32(1)?;
+    log::debug!("surface_get_dc: out=0x{out:08x} -> hdc=0xdead1001");
     if out != 0 {
         ctx.cpu.write_mem(out, &0xDEAD_1001u32.to_le_bytes())?;
     }
@@ -437,9 +540,25 @@ fn surface_get_dd_interface(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Ke
     Ok(DispatchOutcome::ReturnedR0(0))
 }
 
+/// Size of the synthetic framebuffer mapping.
+///
+/// `ensure_framebuffer` maps this region exactly once, but the
+/// framebuffer's own dimensions can grow afterwards -- Asphalt 4
+/// starts at 240x320 and then presents a 242x402 surface, which is
+/// larger than the originally mapped 0x26000 bytes. The guest holds
+/// the base pointer it got from Lock and blits straight past the end
+/// of the old mapping, and every scanline past the boundary fails
+/// with WRITE_UNMAPPED. Rather than track the mapped size and remap
+/// on every resize, reserve a region comfortably larger than any
+/// plausible Pocket PC surface (4 MB covers e.g. 640x480 at 32bpp
+/// several times over) so a resize can never outgrow it. The pages
+/// are only backed as they're touched, so the reservation is cheap.
+const FRAMEBUFFER_REGION_SIZE: u32 = 0x40_0000;
+
 fn ensure_framebuffer(ctx: &mut CallCtx<'_>) -> Result<(), KernelError> {
     if !ctx.kernel.fb_mapped {
-        let size = pocket_cpu::round_up_to_page(ctx.kernel.framebuffer.byte_size());
+        let needed = pocket_cpu::round_up_to_page(ctx.kernel.framebuffer.byte_size());
+        let size = needed.max(FRAMEBUFFER_REGION_SIZE);
         ctx.cpu
             .map_region(SYNTHETIC_FRAMEBUFFER_BASE, size, Prot::READ | Prot::WRITE)?;
         ctx.cpu
@@ -456,6 +575,16 @@ fn surface_is_lost(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
 fn surface_lock(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     ensure_framebuffer(ctx)?;
     let desc = ctx.arg_u32(2)?;
+    // Diagnostic: we have never actually confirmed that the guest
+    // calls Lock at all on the frame it blits. If these lines never
+    // appear, the guest is getting its destination base from some
+    // other route entirely (GetDC, or the CreateDIBSection bits) and
+    // no amount of correctness work on the surface desc can affect
+    // its blit destination.
+    log::debug!(
+        "surface_lock: desc=0x{desc:08x} -> lpSurface=0x{base:08x}",
+        base = SYNTHETIC_FRAMEBUFFER_BASE
+    );
     if desc != 0 {
         write_surface_desc(ctx, desc, SYNTHETIC_FRAMEBUFFER_BASE)?;
     }
@@ -464,12 +593,22 @@ fn surface_lock(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
 
 fn surface_unlock(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     ensure_framebuffer(ctx)?;
-    let mut pixels = vec![0u8; ctx.kernel.framebuffer.pixels.len()];
+    // Read straight into the framebuffer's own storage.
+    //
+    // This used to allocate a fresh full-frame `Vec` per call, read
+    // into it, compare all of it against the framebuffer, and then
+    // copy all of it across on a difference -- four passes over
+    // ~192 KB (240x400x2) plus a heap allocation, every unlock. At a
+    // couple of unlocks per frame that was the single largest cost in
+    // the frame, and the compare almost never paid off: a game only
+    // unlocks after it has drawn, so the contents have essentially
+    // always changed. Read once, mark dirty unconditionally.
+    //
+    // `cpu` and `kernel` are separate borrows of `CallCtx`, so
+    // reading guest memory directly into the framebuffer is fine.
+    let base = SYNTHETIC_FRAMEBUFFER_BASE;
     ctx.cpu
-        .read_mem_into(SYNTHETIC_FRAMEBUFFER_BASE, &mut pixels)?;
-    if pixels != ctx.kernel.framebuffer.pixels {
-        ctx.kernel.framebuffer.pixels.copy_from_slice(&pixels);
-        ctx.kernel.framebuffer.mark_dirty();
-    }
+        .read_mem_into(base, &mut ctx.kernel.framebuffer.pixels)?;
+    ctx.kernel.framebuffer.mark_dirty();
     Ok(DispatchOutcome::ReturnedR0(0))
 }

--- a/crates/pocket-winceapi/src/gles.rs
+++ b/crates/pocket-winceapi/src/gles.rs
@@ -261,7 +261,7 @@ impl Census {
         let on = forced
             || std::env::var("POCKETHLE_GLES_CENSUS")
                 .map(|v| v != "0")
-                .unwrap_or(true);
+                .unwrap_or(false);
         let secs = std::env::var("POCKETHLE_GLES_CENSUS_SECS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
@@ -281,6 +281,7 @@ impl Census {
                 "all units (POCKETHLE_GLES_ENV_ALL_UNITS)"
             }
         );
+        CENSUS_LIVE.store(on, std::sync::atomic::Ordering::Relaxed);
         Census {
             on,
             period: Duration::from_secs(secs),
@@ -459,6 +460,27 @@ impl Census {
 }
 
 static CENSUS: Lazy<Mutex<Census>> = Lazy::new(|| Mutex::new(Census::new()));
+/// Fast gate for the per-call hooks. Set once, from `Census::new`, to
+/// whether the census is on. When it is off the hooks must not even
+/// touch the census mutex: a 3D title issues tens of thousands of GLES
+/// calls per frame and one extra uncontended lock per call was enough
+/// to starve the audio feed (Asphalt 2 lagged and its looped music
+/// crackled).
+static CENSUS_LIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// Whether `Census::new` has run. The first hook call forces it.
+static CENSUS_READY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// True when per-call census hooks should run. Costs two relaxed
+/// atomic loads once initialized.
+fn census_live() -> bool {
+    use std::sync::atomic::Ordering;
+    if CENSUS_READY.load(Ordering::Acquire) {
+        return CENSUS_LIVE.load(Ordering::Relaxed);
+    }
+    Lazy::force(&CENSUS);
+    CENSUS_READY.store(true, Ordering::Release);
+    CENSUS_LIVE.load(Ordering::Relaxed)
+}
 
 /// Whether to sample per-draw texcoord and colour ranges. Read once,
 /// so the draw path costs an atomic load rather than a mutex.
@@ -472,6 +494,9 @@ static CENSUS_DEEP: Lazy<bool> = Lazy::new(|| {
 /// from inside a [`with_ctx`] closure -- the two locks are always taken
 /// one after the other, never nested.
 fn with_census(f: impl FnOnce(&mut Census)) {
+    if !census_live() {
+        return;
+    }
     let mut guard = match CENSUS.lock() {
         Ok(g) => g,
         Err(p) => p.into_inner(),
@@ -485,6 +510,9 @@ fn with_census(f: impl FnOnce(&mut Census)) {
 /// For the handful of hooks that change what gets drawn rather than
 /// only what gets logged.
 fn with_census_always(f: impl FnOnce(&mut Census)) {
+    if !census_live() {
+        return;
+    }
     let mut guard = match CENSUS.lock() {
         Ok(g) => g,
         Err(p) => p.into_inner(),

--- a/crates/pocket-winceapi/src/gles.rs
+++ b/crates/pocket-winceapi/src/gles.rs
@@ -5,7 +5,9 @@
 //! [`super::WinCeDispatcher::new`] does for `coredll.dll`.
 
 use once_cell::sync::Lazy;
+use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use pocket_gles::context::{Context, GuestMemory};
 use pocket_gles::fixed::{word_to_f32, word_to_f32_bits};
@@ -45,6 +47,903 @@ const COMPRESSED_FORMATS: [u32; 15] = [
     pocket_gles::GL_PALETTE8_RGBA4_OES,
     pocket_gles::GL_PALETTE8_RGB5_A1_OES,
 ];
+
+// ---- draw census (diagnostic) ----------------------------------------------
+//
+// Aggregated per-draw state, sampled at the dispatch layer. It records
+// what a draw was given (bound texture, whether that name holds data,
+// the texture environment, the blend state, and the range the texture
+// coordinates actually span) so a frame can be read back from the log
+// without a debugger.
+//
+// `raster::raster_clipped` keeps the interpolated vertex colour when
+// the sampler returns `None`, and `apply_tex_env`'s `Add` arm
+// saturates, so both "no texture data" and "additive pass over a bright
+// base" end in flat bright geometry. The buckets tell them apart.
+//
+// Environment:
+//   POCKETHLE_GLES_CENSUS=0        turn the whole thing off
+//   POCKETHLE_GLES_CENSUS_SECS=N   summary period, default 1
+//   POCKETHLE_GLES_CENSUS_DEEP=1   also sample texture coordinates,
+//                                  vertex colours and the texture
+//                                  matrix per draw. Off by default:
+//                                  it reads guest memory up to 64
+//                                  times and takes the Context lock
+//                                  on every draw call
+//   POCKETHLE_GLES_SKIP_TEX=6,325  drop draws binding these names
+//   POCKETHLE_GLES_SKIP_ENV=0x104  drop draws with these tex env modes
+//   POCKETHLE_GLES_ENV_OVERRIDE=0x2100
+//                                  force every texture environment mode
+//                                  to this value, whatever the guest asks
+//                                  for -- 0x2100 is MODULATE, 0x1E01 is
+//                                  REPLACE, 0x0104 is ADD
+//   POCKETHLE_GLES_ENV_ALL_UNITS=1
+//                                  restore the old behaviour of letting
+//                                  any texture unit's glTexEnv overwrite
+//                                  the one environment mode Context
+//                                  holds. Off by default: see below
+//
+// The skip lists exist to identify geometry visually: drop a name, see
+// what vanishes from the screen. They force the census on.
+
+const CENSUS_GL_TEXTURE_2D: u32 = 0x0DE1;
+const CENSUS_GL_BLEND: u32 = 0x0BE2;
+const CENSUS_GL_VERTEX_ARRAY: u32 = 0x8074;
+const CENSUS_GL_COLOR_ARRAY: u32 = 0x8076;
+const CENSUS_GL_TEXTURE_COORD_ARRAY: u32 = 0x8078;
+const CENSUS_GL_TEXTURE_ENV_MODE: u32 = 0x2200;
+
+/// Vertices sampled per draw when measuring the texture coordinate
+/// range. A range only needs a handful of points; decoding tens of
+/// thousands of vertices per frame would cost more than the draw.
+const CENSUS_TC_SAMPLES: u32 = 32;
+
+/// What we know about one texture name, recorded at upload time.
+#[derive(Clone, Copy, Default)]
+struct TexRecord {
+    levels: u32,
+    width: u32,
+    height: u32,
+    format: u32,
+    ty: u32,
+    bytes: usize,
+    compressed: bool,
+}
+
+/// The state a draw call is bucketed by. Two draws with the same key
+/// are indistinguishable as far as this diagnostic is concerned.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct DrawKey {
+    tex_enabled: bool,
+    name: u32,
+    has_data: bool,
+    tc_enabled: bool,
+    tc_type: u32,
+    tc_size: u32,
+    color_enabled: bool,
+    col_type: u32,
+    col_size: u32,
+    unit: u32,
+    env_mode: u32,
+    blend: bool,
+    blend_src: u32,
+    blend_dst: u32,
+}
+
+/// Accumulated per bucket over one reporting period.
+#[derive(Clone, Copy)]
+struct DrawStats {
+    calls: u64,
+    verts: u64,
+    ranged: bool,
+    smin: f32,
+    smax: f32,
+    tmin: f32,
+    tmax: f32,
+    /// Whether any vertex colour was decoded for this bucket.
+    colored: bool,
+    /// Per-channel minimum and maximum of the vertex colour array, as
+    /// the guest wrote it -- raw and undivided, so a `GL_UNSIGNED_BYTE`
+    /// array reads back 0..255 rather than 0..1.
+    cmin: [f32; 4],
+    cmax: [f32; 4],
+    /// Texture matrix scale and translation, last seen. Column-major,
+    /// so these are m[0], m[5], m[12], m[13].
+    mat: [f32; 4],
+}
+
+impl Default for DrawStats {
+    fn default() -> Self {
+        DrawStats {
+            calls: 0,
+            verts: 0,
+            ranged: false,
+            smin: f32::MAX,
+            smax: f32::MIN,
+            tmin: f32::MAX,
+            tmax: f32::MIN,
+            colored: false,
+            cmin: [f32::MAX; 4],
+            cmax: [f32::MIN; 4],
+            mat: [1.0, 1.0, 0.0, 0.0],
+        }
+    }
+}
+
+/// The texture coordinate array as the guest last described it.
+#[derive(Clone, Copy)]
+struct TcArray {
+    enabled: bool,
+    size: u32,
+    ty: u32,
+    stride: u32,
+    ptr: u32,
+}
+
+struct Census {
+    on: bool,
+    period: Duration,
+    last: Instant,
+    active_unit: u32,
+    bound: [u32; 2],
+    tex_enabled: bool,
+    blend: bool,
+    blend_src: u32,
+    blend_dst: u32,
+    color_array: bool,
+    texcoord_array: bool,
+    vertex_array: bool,
+    tc_size: u32,
+    tc_type: u32,
+    tc_stride: u32,
+    tc_ptr: u32,
+    col_size: u32,
+    col_type: u32,
+    col_stride: u32,
+    col_ptr: u32,
+    env_mode: u32,
+    /// Environment mode as last set for each texture unit, kept apart
+    /// so a second-unit configuration is visible rather than silently
+    /// folded into the one mode the rasterizer reads.
+    env_per_unit: [u32; 2],
+    /// glActiveTexture calls seen per unit.
+    activetex: [u64; 2],
+    env_override: Option<u32>,
+    env_unit0_only: bool,
+    current_color: [f32; 4],
+    skip_names: Vec<u32>,
+    skip_envs: Vec<u32>,
+    skipped: u64,
+    textures: HashMap<u32, TexRecord>,
+    draws: HashMap<DrawKey, DrawStats>,
+    dropped: HashMap<(u32, u32), u64>,
+}
+
+/// Parse a comma-separated list of decimal or `0x`-prefixed values.
+fn census_parse_list(var: &str) -> Vec<u32> {
+    let Ok(raw) = std::env::var(var) else {
+        return Vec::new();
+    };
+    raw.split(',')
+        .filter_map(|item| {
+            let item = item.trim();
+            let stripped = item.strip_prefix("0x").or_else(|| item.strip_prefix("0X"));
+            match stripped {
+                Some(hex) => u32::from_str_radix(hex, 16).ok(),
+                None => item.parse::<u32>().ok(),
+            }
+        })
+        .collect()
+}
+
+impl Census {
+    fn new() -> Self {
+        let skip_names = census_parse_list("POCKETHLE_GLES_SKIP_TEX");
+        let skip_envs = census_parse_list("POCKETHLE_GLES_SKIP_ENV");
+        let env_override = census_parse_list("POCKETHLE_GLES_ENV_OVERRIDE")
+            .first()
+            .copied();
+        // GL keeps texture environment state per texture unit, but
+        // `Context::tex_env` holds exactly one mode. A guest that
+        // configures a second unit -- NFS Undercover alternates 0 and 1
+        // on every object, setting MODULATE on unit 0 and ADD on unit 1
+        // for car bodies -- would otherwise hand the second unit's mode
+        // to the first, and `apply_tex_env`'s Add arm saturates the
+        // result to white. We advertise GL_MAX_TEXTURE_UNITS as 1, so a
+        // second unit's environment cannot affect what we draw and must
+        // not be forwarded.
+        let env_unit0_only = std::env::var("POCKETHLE_GLES_ENV_ALL_UNITS")
+            .map(|v| v == "0")
+            .unwrap_or(true);
+        // A skip list or an override is useless without the state
+        // tracking behind it, so asking for one turns the census on.
+        let forced = !skip_names.is_empty() || !skip_envs.is_empty() || env_override.is_some();
+        let on = forced
+            || std::env::var("POCKETHLE_GLES_CENSUS")
+                .map(|v| v != "0")
+                .unwrap_or(true);
+        let secs = std::env::var("POCKETHLE_GLES_CENSUS_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(1);
+        if !skip_names.is_empty() || !skip_envs.is_empty() {
+            log::info!("GLES census skipping names {skip_names:?} env modes {skip_envs:?}");
+        }
+        if let Some(mode) = env_override {
+            log::info!("GLES census forcing every texture env mode to 0x{mode:04x}");
+        }
+        log::info!(
+            "GLES glTexEnv forwarding: {}",
+            if env_unit0_only {
+                "unit 0 only (per-unit state, GL_MAX_TEXTURE_UNITS is 1)"
+            } else {
+                "all units (POCKETHLE_GLES_ENV_ALL_UNITS)"
+            }
+        );
+        Census {
+            on,
+            period: Duration::from_secs(secs),
+            last: Instant::now(),
+            active_unit: 0,
+            bound: [0; 2],
+            tex_enabled: false,
+            blend: false,
+            blend_src: 0,
+            blend_dst: 0,
+            color_array: false,
+            texcoord_array: false,
+            vertex_array: false,
+            tc_size: 0,
+            tc_type: 0,
+            tc_stride: 0,
+            tc_ptr: 0,
+            col_size: 0,
+            col_type: 0,
+            col_stride: 0,
+            col_ptr: 0,
+            // GL's own default, so a guest that never calls glTexEnv
+            // still reads as MODULATE here.
+            env_mode: 0x2100,
+            env_per_unit: [0x2100; 2],
+            activetex: [0; 2],
+            env_override,
+            env_unit0_only,
+            current_color: [1.0; 4],
+            skip_names,
+            skip_envs,
+            skipped: 0,
+            textures: HashMap::new(),
+            draws: HashMap::new(),
+            dropped: HashMap::new(),
+        }
+    }
+
+    fn report(&mut self) {
+        self.last = Instant::now();
+        let mut buckets: Vec<(DrawKey, DrawStats)> = self.draws.drain().collect();
+        buckets.sort_by_key(|a| std::cmp::Reverse(a.1.calls));
+
+        let calls: u64 = buckets.iter().map(|b| b.1.calls).sum();
+        let verts: u64 = buckets.iter().map(|b| b.1.verts).sum();
+        let textured: u64 = buckets
+            .iter()
+            .filter(|b| b.0.tex_enabled && b.0.has_data)
+            .map(|b| b.1.calls)
+            .sum();
+        let nodata: u64 = buckets
+            .iter()
+            .filter(|b| b.0.tex_enabled && !b.0.has_data)
+            .map(|b| b.1.calls)
+            .sum();
+        let untextured: u64 = buckets
+            .iter()
+            .filter(|b| !b.0.tex_enabled)
+            .map(|b| b.1.calls)
+            .sum();
+        let with_data = self.textures.values().filter(|r| r.bytes > 0).count();
+
+        log::info!(
+            "GLES DRAW CENSUS calls={calls} verts={verts} textured={textured} \
+             texenabled_nodata={nodata} untextured={untextured} skipped={} names={} \
+             names_with_data={} vertexarray={} color=[{:.2} {:.2} {:.2} {:.2}] \
+             tcptr=0x{:08x} tcstride={} activetex=[{} {}] env0=0x{:04x} env1=0x{:04x}",
+            self.skipped,
+            self.textures.len(),
+            with_data,
+            self.vertex_array,
+            self.current_color[0],
+            self.current_color[1],
+            self.current_color[2],
+            self.current_color[3],
+            self.tc_ptr,
+            self.tc_stride,
+            self.activetex[0],
+            self.activetex[1],
+            self.env_per_unit[0],
+            self.env_per_unit[1],
+        );
+        self.skipped = 0;
+        self.activetex = [0; 2];
+
+        for (k, st) in buckets.iter().take(10) {
+            let rec = self.textures.get(&k.name).copied().unwrap_or_default();
+            let range = if st.ranged {
+                format!(
+                    "s=[{:.1}..{:.1}] t=[{:.1}..{:.1}]",
+                    st.smin, st.smax, st.tmin, st.tmax
+                )
+            } else {
+                "s=? t=?".to_string()
+            };
+            let colors = if st.colored {
+                format!(
+                    "col=[{:.0}..{:.0} {:.0}..{:.0} {:.0}..{:.0} {:.0}..{:.0}]",
+                    st.cmin[0],
+                    st.cmax[0],
+                    st.cmin[1],
+                    st.cmax[1],
+                    st.cmin[2],
+                    st.cmax[2],
+                    st.cmin[3],
+                    st.cmax[3],
+                )
+            } else {
+                "col=?".to_string()
+            };
+            log::info!(
+                "  bucket calls={} verts={} tex2d={} name={} data={} {}x{} levels={} \
+                 fmt=0x{:04x} ty=0x{:04x} cmp={} tcarray={} tctype=0x{:04x} tcsize={} \
+                 colorarray={} coltype=0x{:04x} colsize={} unit={} env=0x{:04x} blend={} \
+                 src=0x{:04x} dst=0x{:04x} {} {} texmat=[{:.4} {:.4} {:.4} {:.4}]",
+                st.calls,
+                st.verts,
+                k.tex_enabled,
+                k.name,
+                k.has_data,
+                rec.width,
+                rec.height,
+                rec.levels,
+                rec.format,
+                rec.ty,
+                rec.compressed,
+                k.tc_enabled,
+                k.tc_type,
+                k.tc_size,
+                k.color_enabled,
+                k.col_type,
+                k.col_size,
+                k.unit,
+                k.env_mode,
+                k.blend,
+                k.blend_src,
+                k.blend_dst,
+                range,
+                colors,
+                st.mat[0],
+                st.mat[1],
+                st.mat[2],
+                st.mat[3],
+            );
+        }
+
+        let mut missing: Vec<u32> = buckets
+            .iter()
+            .filter(|b| b.0.tex_enabled && !b.0.has_data)
+            .map(|b| b.0.name)
+            .collect();
+        missing.sort_unstable();
+        missing.dedup();
+        if !missing.is_empty() {
+            let shown = missing.len().min(16);
+            log::info!(
+                "  NO TEXTURE DATA: {} name(s) bound with texturing on, first {}: {:?}",
+                missing.len(),
+                shown,
+                &missing[..shown],
+            );
+        }
+
+        if !self.dropped.is_empty() {
+            let mut d: Vec<((u32, u32), u64)> =
+                self.dropped.iter().map(|(k, v)| (*k, *v)).collect();
+            d.sort_by_key(|a| std::cmp::Reverse(a.1));
+            for ((f, t), n) in d.iter().take(6) {
+                log::info!(
+                    "  DROPPED UPLOAD format=0x{f:04x} type=0x{t:04x} count={n} \
+                     (texel_bytes rejected the pair; the texture kept no data)"
+                );
+            }
+        }
+    }
+}
+
+static CENSUS: Lazy<Mutex<Census>> = Lazy::new(|| Mutex::new(Census::new()));
+
+/// Whether to sample per-draw texcoord and colour ranges. Read once,
+/// so the draw path costs an atomic load rather than a mutex.
+static CENSUS_DEEP: Lazy<bool> = Lazy::new(|| {
+    std::env::var("POCKETHLE_GLES_CENSUS_DEEP")
+        .map(|v| v != "0")
+        .unwrap_or(false)
+});
+
+/// Run `f` against the census, unless it is switched off. Never called
+/// from inside a [`with_ctx`] closure -- the two locks are always taken
+/// one after the other, never nested.
+fn with_census(f: impl FnOnce(&mut Census)) {
+    let mut guard = match CENSUS.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    if guard.on {
+        f(&mut guard);
+    }
+}
+
+/// Like [`with_census`], but runs even when reporting is switched off.
+/// For the handful of hooks that change what gets drawn rather than
+/// only what gets logged.
+fn with_census_always(f: impl FnOnce(&mut Census)) {
+    let mut guard = match CENSUS.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    f(&mut guard);
+}
+
+fn census_enable(cap: u32, on: bool) {
+    with_census(|c| match cap {
+        CENSUS_GL_TEXTURE_2D => c.tex_enabled = on,
+        CENSUS_GL_BLEND => c.blend = on,
+        _ => {}
+    });
+}
+
+fn census_blend_func(src: u32, dst: u32) {
+    with_census(|c| {
+        c.blend_src = src;
+        c.blend_dst = dst;
+    });
+}
+
+fn census_client_state(array: u32, on: bool) {
+    with_census(|c| match array {
+        CENSUS_GL_COLOR_ARRAY => c.color_array = on,
+        CENSUS_GL_TEXTURE_COORD_ARRAY => c.texcoord_array = on,
+        CENSUS_GL_VERTEX_ARRAY => c.vertex_array = on,
+        _ => {}
+    });
+}
+
+fn census_active_unit(unit: u32) {
+    with_census_always(|c| {
+        let unit = unit.min(1);
+        c.active_unit = unit;
+        c.activetex[unit as usize] += 1;
+    });
+}
+
+fn census_bind(target: u32, name: u32) {
+    with_census(|c| {
+        if target == CENSUS_GL_TEXTURE_2D {
+            let unit = c.active_unit as usize;
+            c.bound[unit] = name;
+        }
+    });
+}
+
+/// Record an upload against whatever name is bound right now. `wanted`
+/// is true when the guest passed a non-null pixel pointer, so a zero
+/// `bytes` with `wanted` set is a silently discarded upload.
+#[allow(clippy::too_many_arguments)]
+fn census_upload(
+    level: i32,
+    width: u32,
+    height: u32,
+    format: u32,
+    ty: u32,
+    bytes: usize,
+    wanted: bool,
+    compressed: bool,
+) {
+    with_census(|c| {
+        let name = c.bound[c.active_unit as usize];
+        {
+            let rec = c.textures.entry(name).or_default();
+            rec.levels += 1;
+            if level == 0 {
+                rec.width = width;
+                rec.height = height;
+                rec.format = format;
+                rec.ty = ty;
+                rec.compressed = compressed;
+                rec.bytes = bytes;
+            } else if bytes > 0 {
+                rec.bytes += bytes;
+            }
+        }
+        if wanted && bytes == 0 {
+            *c.dropped.entry((format, ty)).or_insert(0) += 1;
+        }
+    });
+}
+
+fn census_sub_upload(bytes: usize) {
+    with_census(|c| {
+        let name = c.bound[c.active_unit as usize];
+        let rec = c.textures.entry(name).or_default();
+        rec.bytes += bytes;
+    });
+}
+
+fn census_delete(names: &[u32]) {
+    with_census(|c| {
+        for n in names {
+            c.textures.remove(n);
+        }
+    });
+}
+
+fn census_color_pointer(size: u32, ty: u32, stride: u32, ptr: u32) {
+    with_census(|c| {
+        c.col_size = size;
+        c.col_type = ty;
+        c.col_stride = stride;
+        c.col_ptr = ptr;
+    });
+}
+
+/// Rewrite a texture environment mode when an override is configured.
+/// Returns the value the caller should actually apply, so the override
+/// reaches `Context` and not just the census.
+fn census_env_override(pname: u32, value: u32) -> u32 {
+    if pname != CENSUS_GL_TEXTURE_ENV_MODE {
+        return value;
+    }
+    let mut out = value;
+    with_census(|c| {
+        if let Some(mode) = c.env_override {
+            out = mode;
+        }
+    });
+    out
+}
+
+fn census_texcoord_pointer(size: u32, ty: u32, stride: u32, ptr: u32) {
+    with_census(|c| {
+        c.tc_size = size;
+        c.tc_type = ty;
+        c.tc_stride = stride;
+        c.tc_ptr = ptr;
+    });
+}
+
+fn census_tex_env(pname: u32, value: u32) {
+    with_census(|c| {
+        if pname == CENSUS_GL_TEXTURE_ENV_MODE {
+            let unit = c.active_unit as usize;
+            c.env_per_unit[unit] = value;
+            // Mirror what `Context` does: one mode, last writer wins,
+            // whichever unit was active. The per-unit array above is
+            // the ground truth to compare it against.
+            if !c.env_unit0_only || unit == 0 {
+                c.env_mode = value;
+            }
+        }
+    });
+}
+
+/// Whether a glTexEnv call should reach `Context` at all. With the
+/// unit-0-only gate on, a call made while a second unit is active is
+/// recorded but not applied, since the rasterizer has a single unit and
+/// would otherwise take the second unit's mode as its own.
+fn census_env_forward() -> bool {
+    let mut forward = true;
+    with_census_always(|c| {
+        if c.env_unit0_only && c.active_unit != 0 {
+            forward = false;
+        }
+    });
+    forward
+}
+
+fn census_color(rgba: [f32; 4]) {
+    with_census(|c| c.current_color = rgba);
+}
+
+/// True when the current bound name or texture environment is on a skip
+/// list, meaning the caller should drop this draw entirely.
+fn census_should_skip() -> bool {
+    let mut skip = false;
+    with_census(|c| {
+        if c.skip_names.is_empty() && c.skip_envs.is_empty() {
+            return;
+        }
+        let name = c.bound[c.active_unit as usize];
+        if c.skip_names.contains(&name) || c.skip_envs.contains(&c.env_mode) {
+            c.skipped += 1;
+            skip = true;
+        }
+    });
+    skip
+}
+
+/// Snapshot of the texture coordinate array, taken without holding the
+/// census lock across guest memory reads.
+fn census_tc_array() -> TcArray {
+    let mut out = TcArray {
+        enabled: false,
+        size: 0,
+        ty: 0,
+        stride: 0,
+        ptr: 0,
+    };
+    with_census(|c| {
+        out = TcArray {
+            enabled: c.texcoord_array,
+            size: c.tc_size,
+            ty: c.tc_type,
+            stride: c.tc_stride,
+            ptr: c.tc_ptr,
+        };
+    });
+    out
+}
+
+/// The texture matrix scale and translation, for reading alongside the
+/// texcoord range: integer texture coordinates only make sense once
+/// scaled, and this says by how much.
+fn census_texture_matrix() -> [f32; 4] {
+    let m = with_ctx(|c| c.texture_matrix.current().to_vec());
+    if m.len() < 16 {
+        return [1.0, 1.0, 0.0, 0.0];
+    }
+    [m[0], m[5], m[12], m[13]]
+}
+
+/// Bytes in one texture coordinate component.
+fn census_tc_component(ty: u32) -> Option<u32> {
+    Some(match ty {
+        0x1400 | 0x1401 => 1, // GL_BYTE, GL_UNSIGNED_BYTE
+        0x1402 | 0x1403 => 2, // GL_SHORT, GL_UNSIGNED_SHORT
+        0x1406 | 0x140C => 4, // GL_FLOAT, GL_FIXED
+        _ => return None,
+    })
+}
+
+/// Decode one component exactly as the guest wrote it -- no
+/// normalisation, so an integer array reads back as the integers the
+/// game actually supplied.
+fn census_decode_tc(ty: u32, raw: &[u8]) -> f32 {
+    match ty {
+        0x1400 => raw[0] as i8 as f32,
+        0x1401 => raw[0] as f32,
+        0x1402 => i16::from_le_bytes([raw[0], raw[1]]) as f32,
+        0x1403 => u16::from_le_bytes([raw[0], raw[1]]) as f32,
+        0x1406 => f32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]),
+        0x140C => i32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]) as f32 / 65536.0,
+        _ => 0.0,
+    }
+}
+
+/// Measure the S and T range spanned by `indices` into the texture
+/// coordinate array. Returns `None` when there is no client array to
+/// read -- a buffer-object binding, a null pointer, or a type we do not
+/// decode.
+fn census_texcoord_range(
+    cpu: &mut dyn pocket_cpu::Cpu,
+    indices: &[u32],
+) -> Option<(f32, f32, f32, f32)> {
+    let a = census_tc_array();
+    // A vertex-buffer binding leaves a small offset here rather than an
+    // address, and there is no way to reach the buffer store from this
+    // layer, so only client arrays are measured.
+    if !a.enabled || a.ptr < 0x1000 || a.size < 2 {
+        return None;
+    }
+    let comp = census_tc_component(a.ty)?;
+    let stride = if a.stride == 0 {
+        comp.checked_mul(a.size)?
+    } else {
+        a.stride
+    };
+    let (mut smin, mut smax) = (f32::MAX, f32::MIN);
+    let (mut tmin, mut tmax) = (f32::MAX, f32::MIN);
+    let mut seen = 0u32;
+    for &i in indices {
+        let Some(offset) = i.checked_mul(stride) else {
+            continue;
+        };
+        let Some(addr) = a.ptr.checked_add(offset) else {
+            continue;
+        };
+        let Ok(raw) = cpu.read_mem(addr, comp * 2) else {
+            continue;
+        };
+        let s = census_decode_tc(a.ty, &raw[..comp as usize]);
+        let t = census_decode_tc(a.ty, &raw[comp as usize..]);
+        if !s.is_finite() || !t.is_finite() {
+            continue;
+        }
+        smin = smin.min(s);
+        smax = smax.max(s);
+        tmin = tmin.min(t);
+        tmax = tmax.max(t);
+        seen += 1;
+    }
+    if seen == 0 {
+        None
+    } else {
+        Some((smin, smax, tmin, tmax))
+    }
+}
+
+/// Measure the range each vertex colour channel spans over `indices`.
+/// Reported raw, exactly as the guest wrote it: this is here to answer
+/// whether the colour array feeding `apply_tex_env` holds real shading
+/// or has collapsed to white, and a normalised figure would hide the
+/// difference between a decode bug and genuine white geometry.
+fn census_color_range(
+    cpu: &mut dyn pocket_cpu::Cpu,
+    indices: &[u32],
+) -> Option<([f32; 4], [f32; 4])> {
+    let (enabled, size, ty, stride, ptr) = {
+        let mut out = (false, 0u32, 0u32, 0u32, 0u32);
+        with_census(|c| {
+            out = (
+                c.color_array,
+                c.col_size,
+                c.col_type,
+                c.col_stride,
+                c.col_ptr,
+            );
+        });
+        out
+    };
+    if !enabled || ptr < 0x1000 || size == 0 || size > 4 {
+        return None;
+    }
+    let comp = census_tc_component(ty)?;
+    let stride = if stride == 0 {
+        comp.checked_mul(size)?
+    } else {
+        stride
+    };
+    let mut cmin = [f32::MAX; 4];
+    let mut cmax = [f32::MIN; 4];
+    let mut seen = 0u32;
+    for &i in indices {
+        let Some(offset) = i.checked_mul(stride) else {
+            continue;
+        };
+        let Some(addr) = ptr.checked_add(offset) else {
+            continue;
+        };
+        let Ok(raw) = cpu.read_mem(addr, comp * size) else {
+            continue;
+        };
+        for ch in 0..size as usize {
+            let at = ch * comp as usize;
+            let v = census_decode_tc(ty, &raw[at..]);
+            if !v.is_finite() {
+                continue;
+            }
+            cmin[ch] = cmin[ch].min(v);
+            cmax[ch] = cmax[ch].max(v);
+        }
+        seen += 1;
+    }
+    if seen == 0 {
+        None
+    } else {
+        Some((cmin, cmax))
+    }
+}
+
+/// Up to [`CENSUS_TC_SAMPLES`] evenly spaced vertex indices from a
+/// `glDrawArrays` range.
+fn census_sample_range(first: u32, count: u32) -> Vec<u32> {
+    if count == 0 {
+        return Vec::new();
+    }
+    let step = (count / CENSUS_TC_SAMPLES).max(1);
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < count {
+        out.push(first.saturating_add(i));
+        i += step;
+    }
+    out
+}
+
+/// Up to [`CENSUS_TC_SAMPLES`] indices read out of a `glDrawElements`
+/// index array.
+fn census_sample_elements(
+    cpu: &mut dyn pocket_cpu::Cpu,
+    count: u32,
+    ty: u32,
+    ptr: u32,
+) -> Vec<u32> {
+    if count == 0 || ptr < 0x1000 {
+        return Vec::new();
+    }
+    let width = match ty {
+        0x1401 => 1u32, // GL_UNSIGNED_BYTE
+        0x1403 => 2u32, // GL_UNSIGNED_SHORT
+        _ => return Vec::new(),
+    };
+    let step = (count / CENSUS_TC_SAMPLES).max(1);
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < count {
+        let Some(offset) = i.checked_mul(width) else {
+            break;
+        };
+        let Some(addr) = ptr.checked_add(offset) else {
+            break;
+        };
+        let Ok(raw) = cpu.read_mem(addr, width) else {
+            break;
+        };
+        out.push(if width == 1 {
+            raw[0] as u32
+        } else {
+            u16::from_le_bytes([raw[0], raw[1]]) as u32
+        });
+        i += step;
+    }
+    out
+}
+
+fn census_draw(
+    verts: u32,
+    range: Option<(f32, f32, f32, f32)>,
+    colors: Option<([f32; 4], [f32; 4])>,
+    mat: [f32; 4],
+) {
+    with_census(|c| {
+        let name = c.bound[c.active_unit as usize];
+        let has_data = c.textures.get(&name).map(|r| r.bytes > 0).unwrap_or(false);
+        let key = DrawKey {
+            tex_enabled: c.tex_enabled,
+            name,
+            has_data,
+            tc_enabled: c.texcoord_array,
+            tc_type: c.tc_type,
+            tc_size: c.tc_size,
+            color_enabled: c.color_array,
+            col_type: c.col_type,
+            col_size: c.col_size,
+            unit: c.active_unit,
+            env_mode: c.env_mode,
+            blend: c.blend,
+            blend_src: c.blend_src,
+            blend_dst: c.blend_dst,
+        };
+        let entry = c.draws.entry(key).or_default();
+        entry.calls += 1;
+        entry.verts += verts as u64;
+        entry.mat = mat;
+        if let Some((smin, smax, tmin, tmax)) = range {
+            entry.ranged = true;
+            entry.smin = entry.smin.min(smin);
+            entry.smax = entry.smax.max(smax);
+            entry.tmin = entry.tmin.min(tmin);
+            entry.tmax = entry.tmax.max(tmax);
+        }
+        if let Some((cmin, cmax)) = colors {
+            entry.colored = true;
+            for ch in 0..4 {
+                entry.cmin[ch] = entry.cmin[ch].min(cmin[ch]);
+                entry.cmax[ch] = entry.cmax[ch].max(cmax[ch]);
+            }
+        }
+        if c.last.elapsed() >= c.period {
+            c.report();
+        }
+    });
+}
 
 /// Thin wrapper so `pocket_cpu::Cpu` satisfies `GuestMemory`.
 struct CpuMem<'a>(&'a mut dyn pocket_cpu::Cpu);
@@ -250,31 +1149,31 @@ fn gl_orthox(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
 
 fn gl_enable(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let cap = ctx.arg_u32(0)?;
-    if cap == pocket_gles::GL_FOG {
-        log::debug!("GLES enable fog");
-    }
+    log::debug!("GLES glEnable(0x{cap:04x})");
     with_ctx(|c| c.set_capability(cap, true));
+    census_enable(cap, true);
     Ok(VOID)
 }
 
 fn gl_disable(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let cap = ctx.arg_u32(0)?;
-    if cap == pocket_gles::GL_FOG {
-        log::debug!("GLES disable fog");
-    }
+    log::debug!("GLES glDisable(0x{cap:04x})");
     with_ctx(|c| c.set_capability(cap, false));
+    census_enable(cap, false);
     Ok(VOID)
 }
 
 fn gl_enable_client_state(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let array = ctx.arg_u32(0)?;
     with_ctx(|c| c.set_client_state(array, true));
+    census_client_state(array, true);
     Ok(VOID)
 }
 
 fn gl_disable_client_state(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let array = ctx.arg_u32(0)?;
     with_ctx(|c| c.set_client_state(array, false));
+    census_client_state(array, false);
     Ok(VOID)
 }
 
@@ -317,6 +1216,7 @@ fn gl_alpha_funcx(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
 fn gl_blend_func(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let (s, d) = (ctx.arg_u32(0)?, ctx.arg_u32(1)?);
     with_ctx(|c| c.set_blend_func(s, d));
+    census_blend_func(s, d);
     Ok(VOID)
 }
 
@@ -481,12 +1381,14 @@ fn gl_clear_depthx(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError
 fn gl_color4f(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let c = [argf(ctx, 0)?, argf(ctx, 1)?, argf(ctx, 2)?, argf(ctx, 3)?];
     with_ctx(|g| g.current_color = c);
+    census_color(c);
     Ok(VOID)
 }
 
 fn gl_color4x(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let c = [argx(ctx, 0)?, argx(ctx, 1)?, argx(ctx, 2)?, argx(ctx, 3)?];
     with_ctx(|g| g.current_color = c);
+    census_color(c);
     Ok(VOID)
 }
 
@@ -520,6 +1422,7 @@ fn gl_multi_tex_coord4x(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kernel
 fn gl_active_texture(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let unit = ctx.arg_u32(0)?.saturating_sub(pocket_gles::GL_TEXTURE0);
     with_ctx(|c| c.set_active_texture(unit));
+    census_active_unit(unit);
     Ok(VOID)
 }
 
@@ -552,6 +1455,7 @@ fn gl_color_pointer(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
         ctx.arg_u32(3)?,
     );
     with_ctx(|c| c.set_color_pointer(size, ty, stride, ptr));
+    census_color_pointer(size, ty, stride, ptr);
     Ok(VOID)
 }
 
@@ -568,6 +1472,7 @@ fn gl_tex_coord_pointer(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, Kernel
         stride,
     );
     with_ctx(|c| c.set_texcoord_pointer(size, ty, stride, ptr));
+    census_texcoord_pointer(size, ty, stride, ptr);
     Ok(VOID)
 }
 
@@ -607,12 +1512,15 @@ fn gl_delete_textures(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
         .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
         .collect();
     with_ctx(|c| c.delete_textures(&names));
+    census_delete(&names);
     Ok(VOID)
 }
 
 fn gl_bind_texture(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let (target, name) = (ctx.arg_u32(0)?, ctx.arg_u32(1)?);
+    log::debug!("GLES glBindTexture(target=0x{target:04x}, name={name})");
     with_ctx(|c| c.bind_texture(target, name));
+    census_bind(target, name);
     Ok(VOID)
 }
 
@@ -713,7 +1621,22 @@ fn gl_tex_image_2d(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError
     let ty = ctx.arg_u32(7)?;
     let pixels = ctx.arg_u32(8)?;
     let data = load_texels(ctx, pixels, width, height, format, ty)?;
+    log::debug!(
+        "GLES glTexImage2D level={level} {width}x{height} format=0x{format:04x} \
+         type=0x{ty:04x} pixels=0x{pixels:08x} bytes={}",
+        data.len()
+    );
     with_ctx(|c| c.tex_image_2d(target, level, width, height, format, ty, &data));
+    census_upload(
+        level,
+        width,
+        height,
+        format,
+        ty,
+        data.len(),
+        pixels != 0,
+        false,
+    );
     Ok(VOID)
 }
 
@@ -734,6 +1657,7 @@ fn gl_tex_sub_image_2d(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelE
         return Ok(VOID);
     }
     with_ctx(|c| c.tex_sub_image_2d(target, level, xoff, yoff, width, height, format, ty, &data));
+    census_sub_upload(data.len());
     Ok(VOID)
 }
 
@@ -777,16 +1701,50 @@ fn gl_tex_parameterx(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErr
     Ok(VOID)
 }
 
+/// `glTexParameteriv` / `glTexParameterxv` -- the value is behind a
+/// pointer. Every `pname` GL ES 1.1 accepts here is single-valued.
+fn gl_tex_parameter_iv(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let (target, pname, ptr) = (ctx.arg_u32(0)?, ctx.arg_u32(1)?, ctx.arg_u32(2)?);
+    if ptr == 0 {
+        return Ok(VOID);
+    }
+    let raw = ctx.cpu.read_mem(ptr, 4)?;
+    let value = u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]);
+    with_ctx(|c| c.tex_parameter(target, pname, value));
+    Ok(VOID)
+}
+
+/// `glTexParameterfv`. The float is an enum in disguise for every
+/// `pname` that matters here, so it is truncated rather than scaled --
+/// matching what `gl_tex_parameterf` does with the scalar form.
+fn gl_tex_parameter_fv(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let (target, pname, ptr) = (ctx.arg_u32(0)?, ctx.arg_u32(1)?, ctx.arg_u32(2)?);
+    if ptr == 0 {
+        return Ok(VOID);
+    }
+    let raw = ctx.cpu.read_mem(ptr, 4)?;
+    let value = f32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]) as u32;
+    with_ctx(|c| c.tex_parameter(target, pname, value));
+    Ok(VOID)
+}
+
 fn gl_tex_envf(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let pname = ctx.arg_u32(1)?;
-    let value = argf(ctx, 2)? as u32;
-    with_ctx(|c| c.tex_env(pname, value));
+    let value = census_env_override(pname, argf(ctx, 2)? as u32);
+    if census_env_forward() {
+        with_ctx(|c| c.tex_env(pname, value));
+    }
+    census_tex_env(pname, value);
     Ok(VOID)
 }
 
 fn gl_tex_envx(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
-    let (pname, value) = (ctx.arg_u32(1)?, ctx.arg_u32(2)?);
-    with_ctx(|c| c.tex_env(pname, value));
+    let pname = ctx.arg_u32(1)?;
+    let value = census_env_override(pname, ctx.arg_u32(2)?);
+    if census_env_forward() {
+        with_ctx(|c| c.tex_env(pname, value));
+    }
+    census_tex_env(pname, value);
     Ok(VOID)
 }
 
@@ -802,7 +1760,11 @@ fn tex_env_vector(
         let Ok(word) = ctx.cpu.read_u32_le(ptr) else {
             return Ok(VOID);
         };
-        with_ctx(|c| c.tex_env(pname, decode(word) as u32));
+        let value = census_env_override(pname, decode(word) as u32);
+        if census_env_forward() {
+            with_ctx(|c| c.tex_env(pname, value));
+        }
+        census_tex_env(pname, value);
         return Ok(VOID);
     }
     let Ok(bytes) = ctx.cpu.read_mem(ptr, 16) else {
@@ -828,8 +1790,22 @@ fn gl_tex_envxv(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
 
 fn gl_draw_arrays(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
     let (mode, first, count) = (ctx.arg_u32(0)?, ctx.arg_u32(1)?, ctx.arg_u32(2)?);
+    if census_should_skip() {
+        return Ok(VOID);
+    }
+    let (range, colors, mat) = if *CENSUS_DEEP {
+        let samples = census_sample_range(first, count);
+        (
+            census_texcoord_range(&mut *ctx.cpu, &samples),
+            census_color_range(&mut *ctx.cpu, &samples),
+            census_texture_matrix(),
+        )
+    } else {
+        (None, None, [1.0, 1.0, 0.0, 0.0])
+    };
     let mut mem = CpuMem(ctx.cpu);
     with_ctx(|c| c.draw_arrays(&mut mem, mode, first, count));
+    census_draw(count, range, colors, mat);
     Ok(VOID)
 }
 
@@ -844,8 +1820,22 @@ fn gl_draw_elements(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelErro
         "GLES glDrawElements mode=0x{mode:04x} count={} type=0x{ty:04x} indices=0x{ptr:08x}",
         count,
     );
+    if census_should_skip() {
+        return Ok(VOID);
+    }
+    let (range, colors, mat) = if *CENSUS_DEEP {
+        let samples = census_sample_elements(&mut *ctx.cpu, count, ty, ptr);
+        (
+            census_texcoord_range(&mut *ctx.cpu, &samples),
+            census_color_range(&mut *ctx.cpu, &samples),
+            census_texture_matrix(),
+        )
+    } else {
+        (None, None, [1.0, 1.0, 0.0, 0.0])
+    };
     let mut mem = CpuMem(ctx.cpu);
     with_ctx(|c| c.draw_elements_from_guest(&mut mem, mode, count, ty, ptr));
+    census_draw(count, range, colors, mat);
     Ok(VOID)
 }
 
@@ -1022,7 +2012,47 @@ fn gl_read_pixels(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError>
 /// Entry points whose effect our rasterizer has no equivalent for.
 /// Silently succeeding matches what a device without the feature does
 /// and keeps the guest from bailing out on a spurious `GL_INVALID_*`.
+/// Zero a query's output buffer when the parameter list is
+/// `(pname, params)`.
+///
+/// Four words covers every GL ES 1.1 query in this group -- the widest
+/// is a clip-plane equation.
+fn gl_get_zeroed_1(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let out = ctx.arg_u32(1)?;
+    if out != 0 {
+        ctx.cpu.write_mem(out, &[0u8; 16])?;
+    }
+    Ok(VOID)
+}
+
+/// Zero a query's output buffer when the parameter list is
+/// `(target, pname, params)`.
+fn gl_get_zeroed_2(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let out = ctx.arg_u32(2)?;
+    if out != 0 {
+        ctx.cpu.write_mem(out, &[0u8; 16])?;
+    }
+    Ok(VOID)
+}
+
+/// `GLboolean` query answering `GL_FALSE`.
+fn gl_false(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0))
+}
+
 fn gl_ignored(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(VOID)
+}
+
+/// Same no-op, but records the call. Fixed-function lighting and
+/// material state are not implemented; routing them here instead of
+/// `gl_ignored` makes it visible whether a title actually relies on
+/// them before anyone tries to implement them.
+fn gl_ignored_logged(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let a0 = ctx.arg_u32(0).unwrap_or(0);
+    let a1 = ctx.arg_u32(1).unwrap_or(0);
+    let a2 = ctx.arg_u32(2).unwrap_or(0);
+    log::debug!("GLES unimplemented light/material call (0x{a0:04x}, 0x{a1:04x}, 0x{a2:08x})");
     Ok(VOID)
 }
 
@@ -1044,6 +2074,16 @@ fn gl_compressed_tex_image_2d(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, 
         ctx.cpu.read_mem(data, size).unwrap_or_default()
     };
     with_ctx(|c| c.compressed_tex_image_2d(target, level, width, height, format, &bytes));
+    census_upload(
+        level,
+        width,
+        height,
+        format,
+        0,
+        bytes.len(),
+        data != 0 && size != 0,
+        true,
+    );
     Ok(VOID)
 }
 
@@ -1443,6 +2483,21 @@ fn handler_for(name: &str) -> Option<crate::Handler> {
         "glTexSubImage2D" => gl_tex_sub_image_2d,
         "glTexParameterf" => gl_tex_parameterf,
         "glTexParameterx" => gl_tex_parameterx,
+        // `glTexParameteri` takes the same `(target, pname, param)`
+        // shape and, like the fixed-point form, carries an enum rather
+        // than a scaled number -- `tex_parameter` wants the raw word
+        // either way, so the two share a handler. This is the call
+        // every GL program uses to set its min/mag filter and wrap
+        // mode, so leaving it unresolved is not survivable.
+        "glTexParameteri" => gl_tex_parameterx,
+        // Vector forms: the value sits behind a pointer.
+        "glTexParameteriv" | "glTexParameterxv" => gl_tex_parameter_iv,
+        "glTexParameterfv" => gl_tex_parameter_fv,
+        // Point sprite sizing and distance attenuation. The rasterizer
+        // draws points at a fixed size, so these are accepted and
+        // dropped rather than left to resolve as null.
+        "glPointParameterf" | "glPointParameterfv" | "glPointParameterx"
+        | "glPointParameterxv" => gl_ignored,
         "glTexEnvf" => gl_tex_envf,
         "glTexEnvx" => gl_tex_envx,
         "glTexEnvfv" => gl_tex_envfv,
@@ -1458,6 +2513,36 @@ fn handler_for(name: &str) -> Option<crate::Handler> {
         "glGetFloatv" => gl_get_floatv,
         "glGetString" => gl_get_string,
         "glReadPixels" => gl_read_pixels,
+
+        // The rest of the GL ES 1.1 query family.
+        //
+        // These have to resolve to *something*. A game that fetches its
+        // entry points with `GetProcAddress` stores whatever it gets and
+        // calls it later without checking: NFS Undercover resolves all
+        // of these at startup and then branches to a null Thumb address
+        // (`pc=0x00000001`) the moment it uses one. Returning zeroed
+        // output is a poor answer to the query but a survivable one,
+        // where an unresolved name is fatal.
+        //
+        // Split by where the output pointer sits: `(pname, params)` for
+        // the global getters, `(target, pname, params)` for the ones
+        // scoped to a texture unit, light, material or buffer.
+        "glGetBooleanv" | "glGetFixedv" | "glGetPointerv" | "glGetClipPlanef"
+        | "glGetClipPlanex" => gl_get_zeroed_1,
+        "glGetTexParameterfv" | "glGetTexParameteriv" | "glGetTexEnvfv" | "glGetTexEnviv"
+        | "glGetTexEnvxv" | "glGetLightfv" | "glGetLightxv" | "glGetMaterialfv"
+        | "glGetMaterialxv" | "glGetBufferParameteriv" => gl_get_zeroed_2,
+
+        // `GLboolean` predicates. False is the safe answer: a game that
+        // asks whether a name is a live texture or buffer and is told
+        // "no" re-creates it, where "yes" would have it use a handle we
+        // never made.
+        "glIsEnabled" | "glIsBuffer" | "glIsTexture" => gl_false,
+
+        // Clip planes: accepted and ignored. The rasterizer has no
+        // user clip stage, so geometry that should be clipped is drawn
+        // whole rather than not at all.
+        "glClipPlanef" | "glClipPlanex" => gl_ignored,
 
         // buffer objects
         "glGenBuffers" => gl_gen_buffers,
@@ -1480,7 +2565,7 @@ fn handler_for(name: &str) -> Option<crate::Handler> {
         // colours rather than a black screen or a hard error.
         "glLightf" | "glLightfv" | "glLightx" | "glLightxv" | "glLightModelf"
         | "glLightModelfv" | "glLightModelx" | "glLightModelxv" | "glMaterialf"
-        | "glMaterialfv" | "glMaterialx" | "glMaterialxv" => gl_ignored,
+        | "glMaterialfv" | "glMaterialx" | "glMaterialxv" => gl_ignored_logged,
 
         // No stencil buffer, no logic op, no multisample, no polygon
         // offset, no point/line rasterization, no mipmap hints.
@@ -1553,7 +2638,7 @@ fn reset_for_test(width: u32, height: u32) {
 /// not extensions — and a game that imports by name (Xtrakt does, with
 /// 73 named symbols) resolves them through the name path regardless of
 /// what the ordinal table says.
-const EXTRA_NAMED_EXPORTS: [&str; 12] = [
+const EXTRA_NAMED_EXPORTS: [&str; 40] = [
     "glGenBuffers",
     "glDeleteBuffers",
     "glBindBuffer",
@@ -1565,6 +2650,41 @@ const EXTRA_NAMED_EXPORTS: [&str; 12] = [
     "glCurrentPaletteMatrixOES",
     "glLoadPaletteFromModelViewMatrixOES",
     "glPointSizePointerOES",
+    // The GL ES 1.1 query family, absent from the generated tables for
+    // the same reason as the buffer calls above. A real vendor DLL
+    // exports all of these -- they are core, not extensions -- and a
+    // game resolving them by name gets a valid pointer. NFS Undercover
+    // asks for every one of them at startup and calls into whatever it
+    // was handed, so an unresolved name is a null branch rather than a
+    // missing feature.
+    "glGetBooleanv",
+    "glGetFixedv",
+    "glGetPointerv",
+    "glGetClipPlanef",
+    "glGetClipPlanex",
+    "glGetTexParameterfv",
+    "glGetTexParameteriv",
+    "glGetTexEnvfv",
+    "glGetTexEnviv",
+    "glGetTexEnvxv",
+    "glGetLightfv",
+    "glGetLightxv",
+    "glGetMaterialfv",
+    "glGetMaterialxv",
+    "glGetBufferParameteriv",
+    "glIsEnabled",
+    "glIsBuffer",
+    "glIsTexture",
+    "glClipPlanef",
+    "glClipPlanex",
+    "glTexParameteri",
+    "glTexParameteriv",
+    "glTexParameterfv",
+    "glTexParameterxv",
+    "glPointParameterf",
+    "glPointParameterfv",
+    "glPointParameterx",
+    "glPointParameterxv",
     // Vendor extension, so it is in no Khronos list: the Gizmondo's
     // GoForce driver named the swap-interval call this way and Sticky
     // Balls imports it.

--- a/crates/pocket-winceapi/src/gx.rs
+++ b/crates/pocket-winceapi/src/gx.rs
@@ -16,7 +16,23 @@ use pocket_cpu::Prot;
 use pocket_kernel::SYNTHETIC_FRAMEBUFFER_BASE;
 use pocket_kernel::{DispatchOutcome, KernelError};
 
+use crate::coredll::park_worker;
 use crate::{CallCtx, WinCeDispatcher};
+
+// TEMPORARY INSTRUMENTATION: how often the guest actually presents.
+//
+// Rayman Ultimate renders on a worker thread that calls nothing but
+// `GXBeginDraw` / write pixels / `GXEndDraw`. When the game stops
+// drawing, the question is always the same: did the worker stop being
+// scheduled, or is it running and producing identical frames? These
+// counters are read by the pump census in `coredll` so a single log
+// line answers it.
+pub(crate) static GX_BEGIN_DRAWS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+pub(crate) static GX_END_DRAWS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+pub(crate) static GX_PARKED_WORKERS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+pub(crate) static GX_REPRIMES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Synthetic framebuffer base address. Mapped lazily by
 /// [`gx_open_display`]. The value is chosen well above the thunk
@@ -143,10 +159,12 @@ fn gx_open_display(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError
 }
 
 fn gx_close_display(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    log::trace!("GXCloseDisplay()");
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
 fn gx_begin_draw(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    GX_BEGIN_DRAWS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     ensure_fb_mapped(ctx)?;
     // Push the current host framebuffer state into the guest mapping
     // so the guest sees what was previously painted (e.g. a partial
@@ -161,6 +179,7 @@ fn gx_begin_draw(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
     if ctx.kernel.framebuffer.frame_counter != ctx.kernel.gx_last_pushed_counter
         && !ctx.kernel.framebuffer.is_all_black()
     {
+        GX_REPRIMES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let pitch = guest_pitch_bytes(ctx) as usize;
         let row_bytes = ctx.kernel.framebuffer.stride_bytes() as usize;
         if pitch == row_bytes {
@@ -181,7 +200,9 @@ fn gx_begin_draw(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> 
 }
 
 fn gx_end_draw(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    GX_END_DRAWS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     if !ctx.kernel.fb_mapped {
+        log::trace!("GXEndDraw() -> 1 (framebuffer not mapped; nothing to present)");
         return Ok(DispatchOutcome::ReturnedR0(1));
     }
     let pitch = guest_pitch_bytes(ctx) as usize;
@@ -208,6 +229,33 @@ fn gx_end_draw(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
         ctx.kernel.framebuffer.stride_bytes() as usize,
     );
     let changed = ctx.kernel.gx_readback_scratch != ctx.kernel.framebuffer.pixels;
+    log::trace!(
+        "GXEndDraw() -> 1 (changed={changed}, frame={})",
+        ctx.kernel.framebuffer.frame_counter
+    );
+    // TEMPORARY INSTRUMENTATION: is the guest actually producing new
+    // pixels? `changed` is the whole question when the emulator is
+    // presenting frames at a steady rate and the picture on screen
+    // never moves. `trace!` above is too noisy to leave on, so mirror
+    // the answer to `info` once a second with enough detail to tell
+    // the three cases apart:
+    //
+    //   changed=0/N, nonzero>0 -> the guest redraws the same image
+    //                             every frame; the simulation is not
+    //                             advancing and the bug is upstream
+    //                             of rendering entirely
+    //   changed=0/N, nonzero=0 -> the guest is drawing nothing at all
+    //                             into the GAPI surface
+    //   changed=N/N            -> pixels do change here, so whatever
+    //                             loses them is downstream: the
+    //                             frontend upload or the panel
+    present_census(
+        &ctx.kernel.gx_readback_scratch,
+        &ctx.kernel.framebuffer.pixels,
+        changed,
+        signature,
+        ctx.kernel.framebuffer.frame_counter,
+    );
     if changed {
         ctx.kernel
             .framebuffer
@@ -216,6 +264,28 @@ fn gx_end_draw(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
         ctx.kernel.framebuffer.mark_dirty();
         ctx.kernel.gx_guest_signature = Some(signature);
         ctx.kernel.gx_last_pushed_counter = ctx.kernel.framebuffer.frame_counter;
+    }
+    // Yield back to the main thread at the frame boundary.
+    //
+    // The cooperative scheduler only ever regains control from a
+    // worker inside `Sleep`, `PeekMessageW` or a `WaitFor*`. A GAPI
+    // render thread calls none of those: Rayman Ultimate's worker is
+    // `GXBeginDraw` / write pixels / `GXEndDraw` and nothing else, so
+    // once `GetMessageW` scheduled it the main thread never ran again
+    // -- four `GetMessageW` calls in the whole session, all before the
+    // worker started. Host input piled up in `pending_input`, which
+    // only the main thread drains, and the game answered no button at
+    // all while happily rendering.
+    //
+    // `GXEndDraw` is the right place because it is exactly one call
+    // per frame, and it is where a real device would have finished
+    // presenting and been preempted anyway. The worker resumes at its
+    // return address with `1` in r0, so the guest cannot tell the
+    // difference. `park_worker` returns `None` on the main thread, so
+    // a single-threaded GAPI title is unaffected.
+    if let Some(outcome) = park_worker(ctx, 1)? {
+        GX_PARKED_WORKERS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return Ok(outcome);
     }
     Ok(DispatchOutcome::ReturnedR0(1))
 }
@@ -231,7 +301,54 @@ fn sample_signature(bytes: &[u8], stride_bytes: usize) -> u64 {
     hash
 }
 
+/// TEMPORARY INSTRUMENTATION: once-a-second summary of what the guest
+/// handed us at `GXEndDraw`.
+///
+/// `changed` counts how many of the last second's presents actually
+/// differed from what was already on the host framebuffer. `bytes` is
+/// how many bytes differed on the most recent one, and `nonzero` how
+/// many bytes of the guest surface are not zero -- which separates
+/// "drew the same picture again" from "drew nothing".
+fn present_census(guest: &[u8], host: &[u8], changed: bool, signature: u64, frame: u64) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT_MS: AtomicU64 = AtomicU64::new(0);
+    static PRESENTS: AtomicU64 = AtomicU64::new(0);
+    static CHANGED: AtomicU64 = AtomicU64::new(0);
+    let presents = PRESENTS.fetch_add(1, Ordering::Relaxed) + 1;
+    if changed {
+        CHANGED.fetch_add(1, Ordering::Relaxed);
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let due = NEXT_MS.load(Ordering::Relaxed);
+    if now < due
+        || NEXT_MS
+            .compare_exchange(due, now + 1000, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+    {
+        return;
+    }
+    let diff_bytes = guest
+        .iter()
+        .zip(host.iter())
+        .filter(|(a, b)| a != b)
+        .count();
+    let nonzero = guest.iter().filter(|b| **b != 0).count();
+    let reprimes = GX_REPRIMES.load(Ordering::Relaxed);
+    let begins = GX_BEGIN_DRAWS.load(Ordering::Relaxed);
+    log::info!(
+        "PRESENT CENSUS presents={presents} changed={} last_changed={changed} \
+         diff_bytes={diff_bytes}/{} nonzero={nonzero} sig=0x{signature:016x} \
+         frame={frame} begins={begins} reprimes={reprimes}",
+        CHANGED.load(Ordering::Relaxed),
+        guest.len(),
+    );
+}
+
 fn gx_suspend(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    log::trace!("GXSuspend()");
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
@@ -240,18 +357,22 @@ fn gx_suspend(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
 /// answer. Without this stub Zuma exits its message-pump after the
 /// first `WM_ACTIVATE` because GAPI returns `0`.
 fn gx_resume(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    log::trace!("GXResume()");
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
 fn gx_open_input(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    log::trace!("GXOpenInput()");
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
 fn gx_close_input(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    log::trace!("GXCloseInput()");
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 
 fn gx_get_default_keys(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    log::trace!("GXGetDefaultKeys()");
     // The function returns a `GXKeyList` value via a hidden pointer
     // passed in r0 (sret on ARM AAPCS). The struct holds 8 key
     // entries of `{SHORT vkXxx; POINT ptXxx;}` — 12 bytes each
@@ -283,6 +404,7 @@ fn gx_get_default_keys(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelE
 }
 
 fn gx_is_display_dram_buffer(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    log::trace!("GXIsDisplayDRAMBuffer()");
     Ok(DispatchOutcome::ReturnedR0(1))
 }
 fn gx_set_viewport(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -318,6 +440,10 @@ fn gx_get_display_properties(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, K
     // is not a pixel-format bit and must not be ORed into ffFormat.
     buf.extend_from_slice(&0x0000_0080u32.to_le_bytes());
     ctx.cpu.write_mem(sret, &buf)?;
+    log::trace!(
+        "GXGetDisplayProperties() -> {width}x{height} {bpp}bpp stride={} ffFormat=0x80",
+        ctx.kernel.framebuffer.stride_bytes()
+    );
     Ok(DispatchOutcome::ReturnedR0(sret))
 }
 
@@ -376,6 +502,7 @@ pub(crate) mod tests {
             window_classes: std::collections::HashMap::new(),
             window_user_data: 0,
             synthetic_timer_id: 0,
+            synthetic_timer_proc: 0,
             synthetic_timer_interval_ms: 16,
             synthetic_timer_next_ms: 0,
             synthetic_paint_next_ms: 0,
@@ -394,7 +521,11 @@ pub(crate) mod tests {
             events: Default::default(),
             semaphores: Default::default(),
             current_thread: 0,
+            next_worker: 0,
             pressed_keys: [false; 256],
+            keys_pressed_since_query: [false; 256],
+            keys_release_pending: [false; 256],
+            keys_observed_down: [false; 256],
             held_keys: Vec::new(),
             key_repeat_next_ms: None,
             key_repeat_cursor: 0,

--- a/crates/pocket-winceapi/src/ole32.rs
+++ b/crates/pocket-winceapi/src/ole32.rs
@@ -4,6 +4,23 @@ use pocket_kernel::{DispatchOutcome, KernelError};
 
 use crate::{CallCtx, WinCeDispatcher};
 
+/// Distinct from coredll's and ddraw's own fake module handles --
+/// each subsystem that synthesizes callable thunks via
+/// `register_handler` picks its own private key so they can't
+/// collide, and `dynamic_address` below falls back to the shared
+/// `0x1000_0000` bucket regardless of which one was used to
+/// register.
+const FAKE_MODULE_HANDLE: u32 = 0x1000_0004;
+
+/// Number of vtable slots to fill for a synthesized fake COM object.
+/// Real DirectShow interfaces like `IGraphBuilder` have a few dozen
+/// methods across their inheritance chain; we don't know which one a
+/// given game will call, so we install this many identical stub
+/// entries -- comfortably more than any single interface a Pocket PC
+/// game is likely to touch -- so a virtual call through any
+/// plausible vtable offset lands on a safe stub instead of
+/// unmapped/garbage memory.
+const FAKE_COM_VTABLE_SIZE: usize = 64;
 const WMP_METHODS: [&str; 38] = [
     "wmp_query_interface",
     "wmp_add_ref",
@@ -65,6 +82,51 @@ pub fn register(d: &mut WinCeDispatcher) {
     }
     d.register_handler(dll, WMP_CHILD_METHOD, wmp_child_method);
     d.register_constant(dll, "CoGetMalloc", 0, zero_returning);
+    // Registered under "coredll.dll" purely to get a real,
+    // ARM-callable thunk address for an arbitrary function name --
+    // matching the same trick ddraw.rs uses for its fake vtables.
+    // The names are never looked up as real coredll exports.
+    d.register_handler("coredll.dll", "ole32_com_refcount_stub", com_refcount_stub);
+    d.register_handler("coredll.dll", "ole32_com_method_fail", com_method_fail);
+}
+
+fn dynamic_address(ctx: &CallCtx<'_>, name: &str) -> u32 {
+    ctx.kernel
+        .dynamic_exports
+        .get(&FAKE_MODULE_HANDLE)
+        .and_then(|m| m.get(name).copied())
+        .or_else(|| {
+            ctx.kernel
+                .dynamic_exports
+                .get(&0x1000_0000)
+                .and_then(|m| m.get(name).copied())
+        })
+        .unwrap_or(0)
+}
+
+/// Slots 1 (AddRef) and 2 (Release): these return a bare refcount,
+/// not an HRESULT, and games essentially never branch on that value
+/// -- so a constant harmless number is fine here, unlike every other
+/// slot below.
+fn com_refcount_stub(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(1))
+}
+
+/// Every other vtable slot on a synthesized fake COM object,
+/// including slot 0 (QueryInterface). We've now seen this game check
+/// every COM-related return value it makes (CoCreateInstance's own
+/// result, then QueryInterface's) and take a clean, working bail-out
+/// path on failure every single time -- but never verified that any
+/// later, unguarded use of a "successfully" returned interface or
+/// output value is actually safe, and empirically it isn't (a
+/// generic status-logging routine dereferenced an output field a
+/// "successful" call never really populated). Since we don't
+/// implement any real functionality behind this object, honestly
+/// reporting failure here is both the safer default in general and
+/// the one consistent with everything we've actually confirmed this
+/// game does correctly.
+fn com_method_fail(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    Ok(DispatchOutcome::ReturnedR0(0x8000_4001)) // E_NOTIMPL
 }
 
 fn s_ok(_ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
@@ -128,8 +190,44 @@ fn co_create_instance(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelEr
     let clsid_bytes = ctx.cpu.read_mem(clsid, 16)?;
     let iid_bytes = ctx.cpu.read_mem(iid, 16)?;
     if clsid_bytes != CLSID_WMP || iid_bytes != IID_WMP_PLAYER {
-        ctx.cpu.write_mem(out, &0u32.to_le_bytes())?;
-        return Ok(DispatchOutcome::ReturnedR0(0x8000_4002));
+        // Not a class we know. Writing NULL and returning the honest COM
+        // failure turned out to crash games like Asphalt 4: it requests
+        // CLSID_FilterGraph for optional DirectShow video playback and
+        // handles that specific failure cleanly, but a separate
+        // status-logging routine elsewhere in the game dereferences the
+        // object later without checking, and a hard NULL there is an
+        // unrecoverable guest-code crash. Hand back a real,
+        // dereferenceable object whose every method honestly reports
+        // failure instead -- see `com_method_fail` -- so a null-pointer
+        // crash is impossible either way while a game that checks each
+        // result still sees consistent failures and takes its own
+        // working bail-out path.
+        let refcount_addr = dynamic_address(ctx, "ole32_com_refcount_stub");
+        let fail_addr = dynamic_address(ctx, "ole32_com_method_fail");
+        let table = ctx
+            .kernel
+            .heap
+            .alloc(FAKE_COM_VTABLE_SIZE as u32 * 4)
+            .unwrap_or(0);
+        let object = ctx.kernel.heap.alloc(4).unwrap_or(0);
+        if table == 0 || object == 0 || refcount_addr == 0 || fail_addr == 0 {
+            ctx.cpu.write_mem(out, &0u32.to_le_bytes())?;
+            return Ok(DispatchOutcome::ReturnedR0(0x8000_4001)); // E_NOTIMPL
+        }
+        // Slot 0 (QueryInterface) and every real method (slot 3+) fail
+        // honestly. Slots 1/2 (AddRef/Release) get the harmless refcount
+        // stub -- see `com_refcount_stub` for why those are different.
+        ctx.cpu.write_mem(table, &fail_addr.to_le_bytes())?;
+        ctx.cpu.write_mem(table + 4, &refcount_addr.to_le_bytes())?;
+        ctx.cpu.write_mem(table + 8, &refcount_addr.to_le_bytes())?;
+        for i in 3..FAKE_COM_VTABLE_SIZE {
+            ctx.cpu
+                .write_mem(table + i as u32 * 4, &fail_addr.to_le_bytes())?;
+        }
+        ctx.cpu.write_mem(object, &table.to_le_bytes())?;
+        log::debug!("CoCreateInstance -> fake failing COM object at 0x{object:08x}");
+        ctx.cpu.write_mem(out, &object.to_le_bytes())?;
+        return Ok(DispatchOutcome::ReturnedR0(0));
     }
     let vtable_slots = WMP_CHILD_SLOTS.max(WMP_METHODS.len());
     let vtable = ctx

--- a/crates/pocket-winceapi/src/zlib.rs
+++ b/crates/pocket-winceapi/src/zlib.rs
@@ -1,0 +1,315 @@
+//! `zlib.dll` -- the `gz*` stdio-style API.
+//!
+//! Several Pocket PC titles ship a copy of zlib alongside the game and
+//! read their data straight out of gzip files: Rayman Ultimate keeps
+//! its level data in `PCMAP\ALLFIX.DAT.gz` and friends, and a failed
+//! `gzopen` there surfaces as the game's own "Can not open file ...
+//! (load_all_fix)" dialog.
+//!
+//! The implementation decompresses eagerly: `gzopen` reads the whole
+//! host file through the VFS, inflates it into memory, and every later
+//! call just walks that buffer. Real zlib streams incrementally, but
+//! these are level/asset files of a few hundred KB at most, and doing
+//! it up front keeps `gzseek` (which games use freely, including
+//! seeking backwards) trivial and exact -- streaming would otherwise
+//! need to re-inflate from the start on every rewind.
+//!
+//! Following zlib's own behaviour, a file that is *not* gzip-compressed
+//! is passed through verbatim rather than treated as an error: real
+//! `gzread` transparently reads uncompressed files, and titles rely on
+//! that to ship the same code path for packed and loose data.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
+use pocket_kernel::{DispatchOutcome, KernelError};
+
+use crate::coredll::{open_cstr_path, read_cstr_string};
+use crate::{CallCtx, WinCeDispatcher};
+
+/// Base for synthesized `gzFile` handles. Deliberately far away from
+/// the VFS's own handle space so a `gzFile` accidentally passed to
+/// `fread` (or vice versa) fails loudly instead of reading a
+/// half-unrelated file.
+const GZ_HANDLE_BASE: u32 = 0x477A_0000;
+
+/// zlib's `Z_OK` / `Z_STREAM_ERROR`.
+const Z_OK: u32 = 0;
+const Z_STREAM_ERROR: u32 = (-2i32) as u32;
+
+struct GzFile {
+    /// Fully decompressed contents.
+    data: Vec<u8>,
+    /// Read cursor within `data`.
+    pos: usize,
+}
+
+static OPEN_FILES: Lazy<Mutex<HashMap<u32, GzFile>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static NEXT_HANDLE: Mutex<u32> = Mutex::new(GZ_HANDLE_BASE);
+
+/// DLL names the `gz*` entry points show up under.
+///
+/// zlib is a static library, so a title that uses it exports the
+/// symbols from whatever DLL it happened to get linked into. Rayman
+/// Ultimate ships it as `zlib.dll`; a different build of the same game
+/// exports the identical functions from `alib.dll`. The
+/// implementation does not care which, so register the same handlers
+/// for each known spelling rather than duplicating them.
+const ZLIB_DLL_NAMES: &[&str] = &["zlib.dll", "alib.dll", "zlibce.dll", "libz.dll"];
+
+pub fn register(d: &mut WinCeDispatcher) {
+    for &dll in ZLIB_DLL_NAMES {
+        d.register_handler(dll, "gzopen", gzopen);
+        d.register_handler(dll, "gzread", gzread);
+        d.register_handler(dll, "gzclose", gzclose);
+        d.register_handler(dll, "gzseek", gzseek);
+        d.register_handler(dll, "gztell", gztell);
+        d.register_handler(dll, "gzrewind", gzrewind);
+        d.register_handler(dll, "gzeof", gzeof);
+        d.register_handler(dll, "gzgetc", gzgetc);
+        // Sizing helpers some builds use instead of seek/tell. Not
+        // real zlib exports in every version, but harmless to offer.
+        d.register_handler(dll, "gzlength", gzlength);
+        d.register_handler(dll, "gzsize", gzlength);
+    }
+}
+
+/// Decompress `raw` if it carries the gzip magic, otherwise hand it
+/// back untouched (see the module docs -- this mirrors zlib's
+/// transparent handling of uncompressed input).
+fn inflate_if_gzip(raw: Vec<u8>, path: &str) -> Vec<u8> {
+    if raw.len() < 2 || raw[0] != 0x1f || raw[1] != 0x8b {
+        log::debug!("gzopen({path:?}): not gzip-compressed, passing through {} bytes", raw.len());
+        return raw;
+    }
+    let mut out = Vec::new();
+    let mut decoder = flate2::read::GzDecoder::new(&raw[..]);
+    match decoder.read_to_end(&mut out) {
+        Ok(_) => {
+            log::debug!(
+                "gzopen({path:?}): inflated {} bytes -> {} bytes",
+                raw.len(),
+                out.len()
+            );
+            out
+        }
+        Err(e) => {
+            // A truncated or corrupt member still yields whatever
+            // inflated cleanly before the error; a game reading a
+            // partially-recoverable asset is better off with that than
+            // with nothing.
+            log::warn!("gzopen({path:?}): inflate failed after {} bytes: {e}", out.len());
+            out
+        }
+    }
+}
+
+/// `gzFile gzopen(const char *path, const char *mode)`
+fn gzopen(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let path_p = ctx.arg_u32(0)?;
+    let mode_p = ctx.arg_u32(1)?;
+    let path = read_cstr_string(ctx, path_p, 260)?;
+    let mode = read_cstr_string(ctx, mode_p, 8)?;
+
+    // Writing a gzip stream is not supported; report failure rather
+    // than silently accepting data the game would never get back.
+    if mode.starts_with('w') || mode.starts_with('a') {
+        log::warn!("gzopen({path:?}, {mode:?}): write modes are not supported -> NULL");
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+
+    // Reuse the CRT path resolver so all the guest-path spellings and
+    // mount fallbacks that `fopen` understands work here too.
+    let handle = open_cstr_path(ctx, &path, "rb");
+    if handle == 0 {
+        log::debug!("gzopen({path:?}, {mode:?}) -> NULL (not found)");
+        return Ok(DispatchOutcome::ReturnedR0(0));
+    }
+
+    let mut raw = Vec::new();
+    let mut chunk = [0u8; 64 * 1024];
+    loop {
+        match ctx.kernel.vfs.read(handle, &mut chunk) {
+            Some(0) | None => break,
+            Some(n) => raw.extend_from_slice(&chunk[..n]),
+        }
+    }
+    ctx.kernel.vfs.close(handle);
+
+    let data = inflate_if_gzip(raw, &path);
+
+    let mut next = NEXT_HANDLE.lock().unwrap();
+    let gz_handle = *next;
+    *next = next.wrapping_add(1);
+    drop(next);
+    OPEN_FILES
+        .lock()
+        .unwrap()
+        .insert(gz_handle, GzFile { data, pos: 0 });
+    log::debug!("gzopen({path:?}, {mode:?}) -> 0x{gz_handle:08x}");
+    Ok(DispatchOutcome::ReturnedR0(gz_handle))
+}
+
+/// `int gzread(gzFile file, voidp buf, unsigned len)`
+fn gzread(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let buf = ctx.arg_u32(1)?;
+    let len = ctx.arg_u32(2)? as usize;
+
+    let chunk = {
+        let mut files = OPEN_FILES.lock().unwrap();
+        let Some(file) = files.get_mut(&handle) else {
+            log::warn!("gzread(0x{handle:08x}): unknown handle -> -1");
+            return Ok(DispatchOutcome::ReturnedR0(Z_STREAM_ERROR));
+        };
+        let end = file.data.len().min(file.pos.saturating_add(len));
+        let chunk = file.data[file.pos..end].to_vec();
+        file.pos = end;
+        chunk
+    };
+    if buf != 0 && !chunk.is_empty() {
+        ctx.cpu.write_mem(buf, &chunk)?;
+    }
+    log::trace!("gzread(0x{handle:08x}, {len}) -> {}", chunk.len());
+    Ok(DispatchOutcome::ReturnedR0(chunk.len() as u32))
+}
+
+/// `int gzclose(gzFile file)`
+fn gzclose(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let removed = OPEN_FILES.lock().unwrap().remove(&handle).is_some();
+    log::debug!("gzclose(0x{handle:08x}) -> {}", if removed { "Z_OK" } else { "Z_STREAM_ERROR" });
+    Ok(DispatchOutcome::ReturnedR0(if removed {
+        Z_OK
+    } else {
+        Z_STREAM_ERROR
+    }))
+}
+
+/// `z_off_t gzseek(gzFile file, z_off_t offset, int whence)`
+fn gzseek(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let offset = ctx.arg_u32(1)? as i32;
+    let whence = ctx.arg_u32(2)?;
+    let mut files = OPEN_FILES.lock().unwrap();
+    let Some(file) = files.get_mut(&handle) else {
+        log::debug!("gzseek(0x{handle:08x}, {offset}, {whence}): unknown handle -> -1");
+        return Ok(DispatchOutcome::ReturnedR0((-1i32) as u32));
+    };
+    // SEEK_SET = 0, SEEK_CUR = 1, SEEK_END = 2.
+    //
+    // Real zlib refuses SEEK_END on a read stream, because it is
+    // decompressing incrementally and does not know where the end is
+    // without inflating everything first. We already have the whole
+    // file in memory, so we can answer exactly -- and it matters:
+    // seek-to-end followed by gztell is the standard way to size a
+    // file, and returning -1 here left Rayman computing a length of
+    // zero and then subtracting a 128-byte header, which is where the
+    // 0xFFFFFF80 allocation came from.
+    let base = match whence {
+        0 => 0i64,
+        1 => file.pos as i64,
+        2 => file.data.len() as i64,
+        _ => {
+            log::debug!("gzseek(0x{handle:08x}): bad whence {whence} -> -1");
+            return Ok(DispatchOutcome::ReturnedR0((-1i32) as u32));
+        }
+    };
+    let target = (base + offset as i64).clamp(0, file.data.len() as i64);
+    file.pos = target as usize;
+    log::trace!(
+        "gzseek(0x{handle:08x}, {offset}, whence={whence}) -> {} (of {})",
+        file.pos,
+        file.data.len()
+    );
+    Ok(DispatchOutcome::ReturnedR0(file.pos as u32))
+}
+
+/// `z_off_t gztell(gzFile file)`
+fn gztell(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let files = OPEN_FILES.lock().unwrap();
+    let pos = files
+        .get(&handle)
+        .map(|f| f.pos as u32)
+        .unwrap_or((-1i32) as u32);
+    log::trace!("gztell(0x{handle:08x}) -> {pos}");
+    Ok(DispatchOutcome::ReturnedR0(pos))
+}
+
+/// `int gzrewind(gzFile file)`
+fn gzrewind(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let mut files = OPEN_FILES.lock().unwrap();
+    match files.get_mut(&handle) {
+        Some(file) => {
+            file.pos = 0;
+            Ok(DispatchOutcome::ReturnedR0(Z_OK))
+        }
+        None => Ok(DispatchOutcome::ReturnedR0(Z_STREAM_ERROR)),
+    }
+}
+
+/// Uncompressed length of an open file. Not a standard zlib export,
+/// but some ports add one; costs nothing to answer since we already
+/// hold the inflated bytes.
+fn gzlength(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let files = OPEN_FILES.lock().unwrap();
+    let len = files
+        .get(&handle)
+        .map(|f| f.data.len() as u32)
+        .unwrap_or((-1i32) as u32);
+    log::debug!("gzlength(0x{handle:08x}) -> {len}");
+    Ok(DispatchOutcome::ReturnedR0(len))
+}
+
+/// `int gzeof(gzFile file)`
+fn gzeof(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let files = OPEN_FILES.lock().unwrap();
+    let eof = files
+        .get(&handle)
+        .map(|f| u32::from(f.pos >= f.data.len()))
+        .unwrap_or(1);
+    Ok(DispatchOutcome::ReturnedR0(eof))
+}
+
+/// `int gzgetc(gzFile file)` -- returns the byte, or -1 at EOF.
+fn gzgetc(ctx: &mut CallCtx<'_>) -> Result<DispatchOutcome, KernelError> {
+    let handle = ctx.arg_u32(0)?;
+    let mut files = OPEN_FILES.lock().unwrap();
+    let Some(file) = files.get_mut(&handle) else {
+        return Ok(DispatchOutcome::ReturnedR0((-1i32) as u32));
+    };
+    match file.data.get(file.pos).copied() {
+        Some(byte) => {
+            file.pos += 1;
+            Ok(DispatchOutcome::ReturnedR0(u32::from(byte)))
+        }
+        None => Ok(DispatchOutcome::ReturnedR0((-1i32) as u32)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_through_uncompressed_input() {
+        let raw = b"plain bytes".to_vec();
+        assert_eq!(inflate_if_gzip(raw.clone(), "x"), raw);
+    }
+
+    #[test]
+    fn inflates_gzip_input() {
+        use std::io::Write;
+        let mut encoder =
+            flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(b"hello rayman").unwrap();
+        let packed = encoder.finish().unwrap();
+        assert_eq!(inflate_if_gzip(packed, "x"), b"hello rayman");
+    }
+}

--- a/frontends/pocket-desktop/src/app.rs
+++ b/frontends/pocket-desktop/src/app.rs
@@ -69,6 +69,59 @@ pub struct PocketLauncher {
     /// should drive it, while the keybinding editor is in "press a
     /// key" mode.
     binding_capture: Option<GuestButton>,
+    /// How the low-resolution guest framebuffer is magnified to fill
+    /// the window. See [`ScaleFilter`].
+    scale_filter: ScaleFilter,
+    /// Route the physical keyboard to the guest as letters and digits
+    /// instead of as game buttons.
+    ///
+    /// A, B, C and S are bound to the console-style buttons a GAPI game
+    /// expects, which makes it impossible to type them -- fine for
+    /// playing, useless the moment a game asks for text (a registration
+    /// code, a high-score name, a save slot). This flips the keyboard
+    /// to ordinary character input for as long as it is on; the
+    /// on-screen pad still drives the game buttons meanwhile.
+    text_input: bool,
+    /// When set, the display is snapped to a whole-number multiple of
+    /// the guest resolution. Keeps pixels square and uniform at the
+    /// cost of leaving a border when the window is not an exact
+    /// multiple of the game's size.
+    integer_scale: bool,
+}
+
+/// Magnification filter for the guest framebuffer.
+///
+/// The guest renders in software at its native resolution (240x400
+/// for Asphalt 4) and there is no way to raise that -- the game
+/// rasterises 3D and blits fixed-size sprite assets into its own
+/// buffer, so "render at higher resolution" is not something the
+/// host can ask for. What the host *can* choose is how that image is
+/// magnified on the way to the screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScaleFilter {
+    /// Nearest-neighbour: every guest pixel becomes a hard square.
+    /// Faithful to the handheld, but blocky on 3D content.
+    Sharp,
+    /// Bilinear: smooths the magnified image. Softer, and usually
+    /// much easier on the eye for 3D scenes, at the cost of blurring
+    /// crisp UI text and sprite edges.
+    Smooth,
+}
+
+impl ScaleFilter {
+    fn label(self) -> &'static str {
+        match self {
+            ScaleFilter::Sharp => "Sharp (nearest)",
+            ScaleFilter::Smooth => "Smooth (bilinear)",
+        }
+    }
+
+    fn texture_options(self) -> egui::TextureOptions {
+        match self {
+            ScaleFilter::Sharp => egui::TextureOptions::NEAREST,
+            ScaleFilter::Smooth => egui::TextureOptions::LINEAR,
+        }
+    }
 }
 
 /// Texture corners for a rotated presentation, in
@@ -181,6 +234,10 @@ impl HeldButtons {
         }
     }
 
+    fn any_held(&self) -> bool {
+        !self.keyboard.is_empty() || !self.pointer.is_empty()
+    }
+
     /// Every VK still held, forgetting all of them. Used when the window
     /// is closing so the guest is not left with a stuck key.
     fn drain_all(&mut self) -> Vec<u16> {
@@ -290,6 +347,9 @@ impl PocketLauncher {
             game_rotation: RotationPref::None,
             running_game_id: None,
             binding_capture: None,
+            scale_filter: ScaleFilter::Smooth,
+            text_input: false,
+            integer_scale: false,
         }
     }
 
@@ -333,10 +393,11 @@ impl PocketLauncher {
     fn upload_frame_texture(&mut self, ctx: &egui::Context, frame: &FrameSnapshot) {
         let size = [frame.width as usize, frame.height as usize];
         let img = egui::ColorImage::from_rgba_unmultiplied(size, &frame.rgba);
+        let opts = self.scale_filter.texture_options();
         if let Some(tex) = self.last_frame_texture.as_mut() {
-            tex.set(img, egui::TextureOptions::NEAREST);
+            tex.set(img, opts);
         } else {
-            let tex = ctx.load_texture("pockethle-fb", img, egui::TextureOptions::NEAREST);
+            let tex = ctx.load_texture("pockethle-fb", img, opts);
             self.last_frame_texture = Some(tex);
         }
         self.frame_stats.record_frame();
@@ -782,6 +843,36 @@ impl PocketLauncher {
                 ui.label("Halt on unimplemented API");
                 ui.checkbox(&mut draft.halt_on_unimplemented, "");
                 ui.end_row();
+
+                // Three states, so a checkbox will not do: "leave it to
+                // the engine", "off", and "on at N ms". A game that has
+                // never needed an opinion should keep not having one,
+                // rather than being pinned to whatever the default
+                // happens to be today.
+                ui.label("Slice watchdog");
+                ui.horizontal(|ui| {
+                    let mut enabled = draft.slice_timeout_ms.is_some();
+                    if ui.checkbox(&mut enabled, "Override").changed() {
+                        draft.slice_timeout_ms = enabled.then_some(16);
+                    }
+                    if let Some(ms) = draft.slice_timeout_ms.as_mut() {
+                        ui.add(
+                            egui::DragValue::new(ms)
+                                .clamp_range(0..=1000u64)
+                                .suffix(" ms"),
+                        );
+                        ui.label(if *ms == 0 { "(preemption off)" } else { "" });
+                    } else {
+                        ui.label("engine default");
+                    }
+                })
+                .response
+                .on_hover_text(
+                    "How long a slice may run without calling a WinCE API before the \
+                     emulator takes the CPU back. Some games need this to escape their \
+                     own input loops; others fault when preempted. 0 turns it off.",
+                );
+                ui.end_row();
             });
 
         // Satellite libraries are not a setting — they are a fact about
@@ -848,6 +939,35 @@ impl PocketLauncher {
                 self.game_rotation = rotation;
                 self.persist_rotation(rotation);
             }
+            ui.label("Scaling");
+            egui::ComboBox::from_id_source("scale_filter")
+                .selected_text(self.scale_filter.label())
+                .show_ui(ui, |ui| {
+                    for filter in [ScaleFilter::Sharp, ScaleFilter::Smooth] {
+                        ui.selectable_value(&mut self.scale_filter, filter, filter.label());
+                    }
+                });
+            if ui
+                .checkbox(&mut self.text_input, "Text entry")
+                .on_hover_text(
+                    "Send the keyboard to the game as letters and digits instead of \
+                     as console buttons. Needed for anything that asks you to type \
+                     (registration codes, high-score names). The on-screen pad still \
+                     works as buttons while this is on.",
+                )
+                .changed()
+            {
+                // The virtual-key codes change meaning across the
+                // switch, so anything still held would never receive a
+                // matching key-up.
+                self.release_all_keys();
+            }
+            ui.checkbox(&mut self.integer_scale, "Integer scale")
+                .on_hover_text(
+                    "Snap the display to a whole-number multiple of the game's \
+                     resolution so every guest pixel stays the same size. Leaves \
+                     a border unless the window is an exact multiple.",
+                );
             if ui.button("Fullscreen (F11)").clicked() {
                 let fullscreen = ui
                     .ctx()
@@ -904,10 +1024,17 @@ impl PocketLauncher {
         } else {
             size
         };
-        let scale = 2.0_f32
-            .min(available.x / rotated_size.x)
+        // Fill the space egui gave us rather than stopping at a fixed
+        // 2x. On a 1080p window a 240x400 game at 2x occupied a small
+        // corner and left most of the window empty; the guest cannot
+        // render at a higher resolution, so magnifying further is the
+        // only way to make use of the display.
+        let mut scale = (available.x / rotated_size.x)
             .min(available.y / rotated_size.y)
             .max(0.1);
+        if self.integer_scale && scale >= 1.0 {
+            scale = scale.floor();
+        }
         let display_size = rotated_size * scale;
         let (rect, _response) = ui.allocate_exact_size(display_size, Sense::click_and_drag());
         let uv = rotation_uv(self.game_rotation);
@@ -1118,7 +1245,12 @@ impl PocketLauncher {
                 ctx.send_viewport_cmd(egui::ViewportCommand::Fullscreen(!fullscreen));
                 continue;
             }
-            let Some(vk) = self.library.config().keybindings.vk_for_key(key.name()) else {
+            let vk = if self.text_input {
+                physical_vk(key)
+            } else {
+                self.library.config().keybindings.vk_for_key(key.name())
+            };
+            let Some(vk) = vk else {
                 continue;
             };
             if pressed {
@@ -1130,6 +1262,19 @@ impl PocketLauncher {
             }
         }
         if ctx.input(|input| input.viewport().close_requested()) {
+            self.release_all_keys();
+        }
+        // Release everything when the window loses focus.
+        //
+        // Key-up arrives through egui only while the window has focus,
+        // so alt-tabbing (or clicking the console) mid-press means the
+        // release is never reported and the guest keeps seeing the key
+        // held forever. A game that polls `GetAsyncKeyState` and waits
+        // for a *fresh* press then never advances again -- which is
+        // exactly how Rayman's intro ended up stuck with A reading as
+        // held for the rest of the session.
+        if !ctx.input(|input| input.focused) && self.held.any_held() {
+            log::debug!("window lost focus with keys held; releasing them");
             self.release_all_keys();
         }
     }
@@ -1271,6 +1416,47 @@ fn rotated_pointer_to_game(
         ((x * game_size.x).floor() as u32).min(max_x) as u16,
         ((y * game_size.y).floor() as u32).min(max_y) as u16,
     )
+}
+
+fn physical_vk(key: egui::Key) -> Option<u16> {
+    // Plain character input: letters and digits use their standard
+    // virtual-key codes, which are what a WinCE text field reads.
+    use egui::Key::*;
+    let letter = |base: u16, k: egui::Key| -> Option<u16> {
+        const LETTERS: [egui::Key; 26] = [
+            A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+        ];
+        LETTERS
+            .iter()
+            .position(|&l| l == k)
+            .map(|i| base + i as u16)
+    };
+    if let Some(vk) = letter(0x41, key) {
+        return Some(vk);
+    }
+    Some(match key {
+        Num0 => 0x30,
+        Num1 => 0x31,
+        Num2 => 0x32,
+        Num3 => 0x33,
+        Num4 => 0x34,
+        Num5 => 0x35,
+        Num6 => 0x36,
+        Num7 => 0x37,
+        Num8 => 0x38,
+        Num9 => 0x39,
+        Backspace => 0x08,
+        Enter => 0x0D,
+        Space => 0x20,
+        Escape => 0x1B,
+        // Arrows stay usable so a code-entry screen can still be
+        // navigated without leaving text mode.
+        ArrowUp => 0x26,
+        ArrowDown => 0x28,
+        ArrowLeft => 0x25,
+        ArrowRight => 0x27,
+        _ => return None,
+    })
 }
 
 impl eframe::App for PocketLauncher {


### PR DESCRIPTION
## What this imports

Changes from a development fork of the project, rebased onto current `main` (three-way merged against `37c8153`).

### Kernel input model (`pocket-kernel`)
- `GetAsyncKeyState` now also reports the real `0x0001` "pressed since last query" bit, with per-key latch tracking (`keys_pressed_since_query`, `keys_release_pending`, `keys_observed_down`). Fixes polling-driven menus (LudiGames' Rayman has no `WM_KEYDOWN` handler at all) where quick taps between polls were silently swallowed.
- The virtual-key state is now maintained in `KernelState::push_input` at queue time instead of only when the guest drains the queue, so polling guests no longer depend on a message pump.
- New `callwatch.rs` module: background watchdog that logs calls that never return.

### WinCE API (`pocket-winceapi`)
- **HTC tilt sensor SDK** (`htcsensorsdk.dll`): `LoadLibraryW` + `HTCSensorOpen`/`HTCSensorClose`/`HTCSensorGetDataOutput` handlers. NFS Undercover shows its tilt-steering button when the sensor loads.
- **DirectShow / CoCreateInstance fallback**: unknown CLSIDs now get a real, dereferenceable COM object whose methods honestly return failure (previously a NULL `ppv` crashed Asphalt 4's status-logging routine).
- **zlib module** (`zlib.rs`): inflate/deflate support backed by `flate2` for games that ship compressed assets.
- **Extended GLES named exports**: the GL ES 1.1 query family and friends (`glGetBooleanv`, `glClipPlanef`, ...) so NFS Undercover's startup lookups resolve.
- **Memory-mapped files**: `CreateFileForMappingW`/`MapViewOfFile`/`UnmapViewOfFile` (Rayman Ultimate loads `letrot.pcx` through the mapping API).
- `GXReprimes` counter instrumentation in `gx.dll`.

### Desktop frontend (`pocket-desktop`)
- **Scale filter** (Sharp/Smooth) and **integer scaling** options for magnifying the guest framebuffer.
- **Text entry mode**: routes the physical keyboard as letters/digits (via `physical_vk`) instead of game buttons — for registration codes, high-score names, etc. Releases all keys when toggled and when the window loses focus (a lost-focus release used to leave Rayman's intro stuck on a held key).

### VFS
- Opens with write access fall back to read-only mounts instead of failing (Rayman's `rb+` opens).
- Directory walks skip unreadable subdirectories instead of aborting the whole search; mount-escape guard refusals no longer hide broader mounts.

## Not ported
- The fork's raw-VK on-screen button layout and D-pad rotation — `main`'s `GuestButton`/`RotationPref` design supersedes them.
- Fork-only worker-scheduling test `two_eligible_workers_are_scheduled_in_turn` (its mechanism was superseded by `resume_worker_reenter`).

## Verification
- `cargo check --workspace --all-targets` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all` applied
- `cargo test --workspace`: 21/21 suites green